### PR TITLE
feat(examples): add `anvil` examples from `ethers-rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,13 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "d5967
 alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "d5967ab", default-features = false }
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "d5967ab", default-features = false }
 
+alloy-core = { version = "0.6.4", default-features = false, features = ["std"] }
+alloy-dyn-abi = { version = "0.6.4", default-features = false, features = [
+    "std",
+] }
+alloy-json-abi = { version = "0.6.4", default-features = false, features = [
+    "std",
+] }
 alloy-primitives = { version = "0.6.4", default-features = false, features = [
     "std",
 ] }
@@ -58,3 +65,12 @@ serde = { version = "1.0", features = ["derive"] }
 coins-bip39 = { version = "0.8.7", default-features = false, features = [
     "english",
 ] }
+
+[patch.crates-io]
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-core = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["Alloy Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/alloy-rs/examples"
 repository = "https://github.com/alloy-rs/examples"
-exclude = ["examples/"]
 publish = false
 
 [workspace.dependencies]

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,10 @@ cargo run --example mnemonic_signer
 
 ## Table of Contents
 
-- [ ] Address book
-- [ ] Anvil
-    - [ ] Boot anvil
-    - [ ] Deploy contracts
-    - [ ] Fork
-    - [ ] Testing
+- [x] Anvil
+    - [x] [Deploy contract](./anvil/examples/deploy_contract_anvil.rs)
+    - [x] [Fork](./anvil/examples/fork_anvil.rs)
+    - [x] [Local](./anvil/examples/local_anvil.rs)
 - [ ] Big numbers
     - [ ] Comparison and equivalence
     - [ ] Conversion

--- a/examples/anvil/Cargo.toml
+++ b/examples/anvil/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples-wallets"
+name = "examples-anvil"
 
 publish.workspace = true
 version.workspace = true
@@ -11,25 +11,15 @@ homepage.workspace = true
 repository.workspace = true
 
 [dev-dependencies]
+alloy-contract.workspace = true
 alloy-network.workspace = true
 alloy-node-bindings.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-client.workspace = true
-alloy-rpc-types.workspace = true
-alloy-signer = { workspace = true, features = [
-    "eip712",
-    "mnemonic",
-    "yubihsm",
-] }
-alloy-signer-ledger.workspace = true
-alloy-signer-trezor.workspace = true
+alloy-signer.workspace = true
 alloy-sol-types.workspace = true
 alloy-transport-http.workspace = true
 
-# TODO: remove after https://github.com/alloy-rs/alloy/pull/309
-coins-bip39.workspace = true
-rand.workspace = true
 reqwest.workspace = true
-serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/anvil/examples/deploy_contract_anvil.rs
+++ b/examples/anvil/examples/deploy_contract_anvil.rs
@@ -1,0 +1,80 @@
+//! Example of deploying a contract to Anvil and interacting with it.
+
+use alloy_network::EthereumSigner;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{U256, U64};
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_signer::LocalWallet;
+use alloy_sol_types::sol;
+use alloy_transport_http::Http;
+use reqwest::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().spawn();
+
+    // Set up wallet
+    let wallet: LocalWallet = anvil.keys()[0].clone().into();
+
+    // Create a provider with a signer and the network.
+    let http = Http::<Client>::new(anvil.endpoint().parse()?);
+    let provider = ProviderBuilder::new()
+        .signer(EthereumSigner::from(wallet))
+        .provider(RootProvider::new(RpcClient::new(http, true)));
+
+    println!("Anvil running at `{}`", anvil.endpoint());
+
+    // Create a contract.
+    sol! {
+        // solc v0.8.24; solc a.sol --via-ir --optimize --bin
+        #[sol(rpc, bytecode="608080604052346100155760d2908161001a8239f35b5f80fdfe60808060405260043610156011575f80fd5b5f3560e01c9081633fb5c1cb1460865781638381f58a14606f575063d09de08a146039575f80fd5b34606b575f366003190112606b575f545f1981146057576001015f55005b634e487b7160e01b5f52601160045260245ffd5b5f80fd5b34606b575f366003190112606b576020905f548152f35b34606b576020366003190112606b576004355f5500fea2646970667358221220bdecd3c1dd631eb40587cafcd6e8297479db76db6a328e18ad1ea5b340852e3864736f6c63430008180033")]
+        contract Counter {
+            uint256 public number;
+
+            function setNumber(uint256 newNumber) public {
+                number = newNumber;
+            }
+
+            function increment() public {
+                number++;
+            }
+        }
+    }
+
+    // Get the base fee for the block.
+    let base_fee = provider.get_gas_price().await?;
+
+    // Deploy the contract.
+    let contract_builder = Counter::deploy_builder(&provider);
+    let estimate = contract_builder.estimate_gas().await?;
+    let contract_address =
+        contract_builder.gas(estimate).gas_price(base_fee).nonce(U64::from(0)).deploy().await?;
+
+    println!("Deployed contract at address: {:?}", contract_address);
+
+    let contract = Counter::new(contract_address, &provider);
+
+    let estimate = contract.setNumber(U256::from(42)).estimate_gas().await?;
+    let builder =
+        contract.setNumber(U256::from(42)).nonce(U64::from(1)).gas(estimate).gas_price(base_fee);
+    let receipt = builder.send().await?.get_receipt().await?;
+
+    println!("Set number to 42: {:?}", receipt.transaction_hash);
+
+    // Increment the number to 43.
+    let estimate = contract.increment().estimate_gas().await?;
+    let builder = contract.increment().nonce(U64::from(2)).gas(estimate).gas_price(base_fee);
+    let receipt = builder.send().await?.get_receipt().await?;
+
+    println!("Incremented number: {:?}", receipt.transaction_hash);
+
+    // Retrieve the number, which should be 43.
+    let Counter::numberReturn { _0 } = contract.number().call().await?;
+
+    println!("Retrieved number: {:?}", _0.to_string());
+
+    Ok(())
+}

--- a/examples/anvil/examples/fork_anvil.rs
+++ b/examples/anvil/examples/fork_anvil.rs
@@ -1,0 +1,14 @@
+//! Example of spinning up a forked Anvil node.
+
+use alloy_node_bindings::Anvil;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.llamarpc.com").spawn();
+
+    println!("Anvil running at `{}`", anvil.endpoint());
+
+    Ok(())
+}

--- a/examples/anvil/examples/local_anvil.rs
+++ b/examples/anvil/examples/local_anvil.rs
@@ -1,0 +1,14 @@
+//! Example of spinning up a local Anvil node.
+
+use alloy_node_bindings::Anvil;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().spawn();
+
+    println!("Anvil running at `{}`", anvil.endpoint());
+
+    Ok(())
+}


### PR DESCRIPTION
Previous PR: https://github.com/alloy-rs/alloy/pull/301

## Motivation

To add examples from `ethers-rs`: `anvil`

## Solution

Includes a new Anvil test (`deploy_contract`) that was planned in `ethers-rs` but not added originally. Adds two other very basic tests for forking and local.

I'm currently managing the `nonces`, `gas` and `gas_price` manually which is not ideal. Preferably `gas` and `gas_price` are derived automatically. I think it is preferable to add support for nonce management to the examples at a later point.