### PR TITLE
feat(layers): Port `middleware` (layers) from `ethers-rs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,9 @@ cargo run --example mnemonic_signer
 - [ ] Events
   - [ ] Logs and filtering
   - [ ] Solidity topics
-- [ ] Middleware
-  - [ ] Builder
-  - [ ] Create custom middleware
-  - [ ] Gas escalator
-  - [ ] Gas oracle
-  - [ ] Nonce manager
-  - [ ] Policy
-  - [ ] Signer
-  - [ ] Time lag
-  - [ ] Transformer
+- [x] Layers
+  - [x] [Nonce manager](./examples/layers/examples/nonce_layer.rs)
+  - [x] [Signature manager](./examples/layers/examples/signer_layer.rs)
 - [ ] Providers
   - [ ] Http
   - [ ] IPC

--- a/examples/layers/Cargo.toml
+++ b/examples/layers/Cargo.toml
@@ -11,14 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dev-dependencies]
-alloy-network.workspace = true
-alloy-node-bindings.workspace = true
-alloy-primitives.workspace = true
-alloy-provider.workspace = true
-alloy-rpc-client.workspace = true
-alloy-rpc-types.workspace = true
-alloy-signer-wallet.workspace = true
-alloy-transport-http.workspace = true
+alloy.workspace = true
 
 eyre.workspace = true
 reqwest.workspace = true

--- a/examples/layers/Cargo.toml
+++ b/examples/layers/Cargo.toml
@@ -20,5 +20,6 @@ alloy-rpc-types.workspace = true
 alloy-signer-wallet.workspace = true
 alloy-transport-http.workspace = true
 
+eyre.workspace = true
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/layers/Cargo.toml
+++ b/examples/layers/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "examples-layers"
+
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dev-dependencies]
+alloy-network.workspace = true
+alloy-node-bindings.workspace = true
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-client.workspace = true
+alloy-rpc-types.workspace = true
+alloy-signer-wallet.workspace = true
+alloy-transport-http.workspace = true
+
+reqwest.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -3,13 +3,11 @@
 use alloy_network::EthereumSigner;
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{address, U256};
-use alloy_provider::{layers::ManagedNonceLayer, Provider, ProviderBuilder, RootProvider};
+use alloy_provider::{layers::ManagedNonceLayer, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
 use alloy_signer_wallet::LocalWallet;
-use alloy_transport_http::Http;
 use eyre::Result;
-use reqwest::Client;
 
 /// In Ethereum, the nonce of a transaction is a number that represents the number of transactions
 /// that have been sent from a particular account. The nonce is used to ensure that transactions are
@@ -30,12 +28,12 @@ async fn main() -> Result<()> {
     let wallet: LocalWallet = anvil.keys()[0].clone().into();
     let from = wallet.address();
 
-    // Create a provider with a signer and the network.
-    let http = Http::<Client>::new(anvil.endpoint().parse()?);
+    // Create a provider with the signer.
+    let http = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
         .layer(ManagedNonceLayer)
         .signer(EthereumSigner::from(wallet))
-        .provider(RootProvider::new(RpcClient::new(http, true)));
+        .on_client(RpcClient::new_http(http));
 
     let tx = TransactionRequest {
         from: Some(from),

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -24,7 +24,7 @@ use reqwest::Client;
 async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH
-    let anvil = Anvil::new().spawn();
+    let anvil = Anvil::new().try_spawn()?;
 
     // Set up the wallets.
     let wallet: LocalWallet = anvil.keys()[0].clone().into();

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -37,6 +37,7 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(wallet))
         .on_client(RpcClient::new_http(http));
 
+    // Create an EIP-1559 type transaction.
     let tx = TransactionRequest::default()
         .with_from(from)
         .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into())
@@ -46,6 +47,7 @@ async fn main() -> Result<()> {
         .with_max_priority_fee_per_gas(U256::from(1e9))
         .with_chain_id(anvil.chain_id());
 
+    // Send the transaction, the nonce (0) is automatically managed by the provider.
     let builder = provider.send_transaction(tx.clone()).await?;
     let node_hash = *builder.tx_hash();
     let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;
@@ -53,6 +55,7 @@ async fn main() -> Result<()> {
 
     println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 
+    // Send the transaction, the nonce (1) is automatically managed by the provider.
     let builder = provider.send_transaction(tx).await?;
     let node_hash = *builder.tx_hash();
     let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -47,13 +47,15 @@ async fn main() -> Result<()> {
     };
 
     let builder = provider.send_transaction(tx.clone()).await?;
-    let pending_transaction = provider.get_transaction_by_hash(*builder.tx_hash()).await?;
+    let node_hash = *builder.tx_hash();
+    let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;
     assert_eq!(pending_transaction.nonce, U64::from(0));
 
     println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 
     let builder = provider.send_transaction(tx).await?;
-    let pending_transaction = provider.get_transaction_by_hash(*builder.tx_hash()).await?;
+    let node_hash = *builder.tx_hash();
+    let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;
     assert_eq!(pending_transaction.nonce, U64::from(1));
 
     println!("Transaction sent with nonce: {}", pending_transaction.nonce);

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -2,7 +2,7 @@
 
 use alloy_network::EthereumSigner;
 use alloy_node_bindings::Anvil;
-use alloy_primitives::{address, U256, U64};
+use alloy_primitives::{address, U256};
 use alloy_provider::{layers::ManagedNonceLayer, Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
@@ -49,14 +49,14 @@ async fn main() -> Result<()> {
     let builder = provider.send_transaction(tx.clone()).await?;
     let node_hash = *builder.tx_hash();
     let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;
-    assert_eq!(pending_transaction.nonce, U64::from(0));
+    assert_eq!(pending_transaction.nonce, 0);
 
     println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 
     let builder = provider.send_transaction(tx).await?;
     let node_hash = *builder.tx_hash();
     let pending_transaction = provider.get_transaction_by_hash(node_hash).await?;
-    assert_eq!(pending_transaction.nonce, U64::from(1));
+    assert_eq!(pending_transaction.nonce, 1);
 
     println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
         .with_gas_limit(U256::from(21000))
         .with_max_fee_per_gas(U256::from(20e9))
         .with_max_priority_fee_per_gas(U256::from(1e9))
-        .with_chain_id(anvil.chain_id().into());
+        .with_chain_id(anvil.chain_id());
 
     let builder = provider.send_transaction(tx.clone()).await?;
     let node_hash = *builder.tx_hash();

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -46,19 +46,17 @@ async fn main() -> Result<()> {
         ..Default::default()
     };
 
-    let pending = provider.send_transaction(tx.clone()).await?;
-    let tx_hash = pending.watch().await?;
-    let mined_tx = provider.get_transaction_by_hash(tx_hash).await?;
-    assert_eq!(mined_tx.nonce, U64::from(0));
+    let builder = provider.send_transaction(tx.clone()).await?;
+    let pending_transaction = provider.get_transaction_by_hash(*builder.tx_hash()).await?;
+    assert_eq!(pending_transaction.nonce, U64::from(0));
 
-    println!("Transaction sent with nonce: {}", mined_tx.nonce);
+    println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 
-    let pending = provider.send_transaction(tx).await?;
-    let tx_hash = pending.watch().await?;
-    let mined_tx = provider.get_transaction_by_hash(tx_hash).await?;
-    assert_eq!(mined_tx.nonce, U64::from(1));
+    let builder = provider.send_transaction(tx).await?;
+    let pending_transaction = provider.get_transaction_by_hash(*builder.tx_hash()).await?;
+    assert_eq!(pending_transaction.nonce, U64::from(1));
 
-    println!("Transaction sent with nonce: {}", mined_tx.nonce);
+    println!("Transaction sent with nonce: {}", pending_transaction.nonce);
 
     Ok(())
 }

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -1,12 +1,13 @@
 //! Example of using the `ManagedNonceLayer` in the provider.
 
-use alloy_network::EthereumSigner;
-use alloy_node_bindings::Anvil;
-use alloy_primitives::{address, U256};
-use alloy_provider::{layers::ManagedNonceLayer, Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_wallet::LocalWallet;
+use alloy::{
+    network::EthereumSigner,
+    node_bindings::Anvil,
+    primitives::{address, U256},
+    providers::{layers::ManagedNonceLayer, Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::wallet::LocalWallet,
+};
 use eyre::Result;
 
 /// In Ethereum, the nonce of a transaction is a number that represents the number of transactions

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -1,0 +1,63 @@
+//! Example of using the `ManagedNonceLayer` in the provider.
+
+use alloy_network::EthereumSigner;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{address, U256, U64};
+use alloy_provider::{layers::ManagedNonceLayer, Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types::request::TransactionRequest;
+use alloy_signer_wallet::LocalWallet;
+use alloy_transport_http::Http;
+use reqwest::Client;
+
+/// In Ethereum, the nonce of a transaction is a number that represents the number of transactions
+/// that have been sent from a particular account. The nonce is used to ensure that transactions are
+/// processed in the order they are intended, and to prevent the same transaction from being
+/// processed multiple times.
+///
+/// The nonce manager in Alloy is a layer that helps you manage the nonce
+/// of transactions by keeping track of the current nonce for a given account and automatically
+/// incrementing it as needed. This can be useful if you want to ensure that transactions are sent
+/// in the correct order, or if you want to avoid having to manually manage the nonce yourself.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().spawn();
+
+    // Set up the wallets.
+    let wallet: LocalWallet = anvil.keys()[0].clone().into();
+    let from = wallet.address();
+
+    // Create a provider with a signer and the network.
+    let http = Http::<Client>::new(anvil.endpoint().parse()?);
+    let provider = ProviderBuilder::new()
+        .layer(ManagedNonceLayer)
+        .signer(EthereumSigner::from(wallet))
+        .provider(RootProvider::new(RpcClient::new(http, true)));
+
+    let tx = TransactionRequest {
+        from: Some(from),
+        value: Some(U256::from(100)),
+        to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+        gas_price: Some(U256::from(20e9)),
+        gas: Some(U256::from(21000)),
+        ..Default::default()
+    };
+
+    let pending = provider.send_transaction(tx.clone()).await?;
+    let tx_hash = pending.watch().await?;
+    let mined_tx = provider.get_transaction_by_hash(tx_hash).await?;
+    assert_eq!(mined_tx.nonce, U64::from(0));
+
+    println!("Transaction sent with nonce: {}", mined_tx.nonce);
+
+    let pending = provider.send_transaction(tx).await?;
+    let tx_hash = pending.watch().await?;
+    let mined_tx = provider.get_transaction_by_hash(tx_hash).await?;
+    assert_eq!(mined_tx.nonce, U64::from(1));
+
+    println!("Transaction sent with nonce: {}", mined_tx.nonce);
+
+    Ok(())
+}

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -8,6 +8,7 @@ use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
 use alloy_signer_wallet::LocalWallet;
 use alloy_transport_http::Http;
+use eyre::Result;
 use reqwest::Client;
 
 /// In Ethereum, the nonce of a transaction is a number that represents the number of transactions
@@ -20,7 +21,7 @@ use reqwest::Client;
 /// incrementing it as needed. This can be useful if you want to ensure that transactions are sent
 /// in the correct order, or if you want to avoid having to manually manage the nonce yourself.
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH
     let anvil = Anvil::new().spawn();

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -1,12 +1,13 @@
 //! Example of using the `SignerLayer` in the provider.
 
-use alloy_network::EthereumSigner;
-use alloy_node_bindings::Anvil;
-use alloy_primitives::{address, b256, U256};
-use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_wallet::LocalWallet;
+use alloy::{
+    network::EthereumSigner,
+    node_bindings::Anvil,
+    primitives::{address, b256, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::wallet::LocalWallet,
+};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -3,13 +3,11 @@
 use alloy_network::EthereumSigner;
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{address, b256, U256};
-use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
 use alloy_signer_wallet::LocalWallet;
-use alloy_transport_http::Http;
 use eyre::Result;
-use reqwest::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,12 +18,12 @@ async fn main() -> Result<()> {
     // Set up the wallets.
     let wallet: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create a provider with a signer and the network.
-    let http = Http::<Client>::new(anvil.endpoint().parse()?);
+    // Create a provider with the signer.
+    let http = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
         // Add the `SignerLayer` to the provider
         .signer(EthereumSigner::from(wallet))
-        .provider(RootProvider::new(RpcClient::new(http, true)));
+        .on_client(RpcClient::new_http(http));
 
     let tx = TransactionRequest {
         nonce: Some(0),

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -15,7 +15,7 @@ use reqwest::Client;
 async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH
-    let anvil = Anvil::new().spawn();
+    let anvil = Anvil::new().try_spawn()?;
 
     // Set up the wallets.
     let wallet: LocalWallet = anvil.keys()[0].clone().into();

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -2,7 +2,7 @@
 
 use alloy_network::EthereumSigner;
 use alloy_node_bindings::Anvil;
-use alloy_primitives::{address, b256, U256, U64};
+use alloy_primitives::{address, b256, U256};
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         .provider(RootProvider::new(RpcClient::new(http, true)));
 
     let tx = TransactionRequest {
-        nonce: Some(U64::from(0)),
+        nonce: Some(0),
         value: Some(U256::from(100)),
         to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
         gas_price: Some(U256::from(20e9)),
@@ -59,9 +59,10 @@ async fn main() -> Result<()> {
 
     let receipt =
         provider.get_transaction_receipt(transaction_hash).await.unwrap().expect("no receipt");
-    let receipt_hash = receipt.transaction_hash.expect("no receipt hash");
+    let receipt_hash = receipt.transaction_hash;
+    assert_eq!(receipt_hash, node_hash);
 
-    println!("Receipt hash matches node hash: {}", receipt_hash == node_hash);
+    println!("Transaction receipt hash matches node hash: {}", receipt_hash == node_hash);
 
     Ok(())
 }

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(wallet))
         .on_client(RpcClient::new_http(http));
 
+    // Create a legacy type transaction.
     let tx = TransactionRequest::default()
         .with_nonce(0)
         .with_from(from)

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -1,7 +1,7 @@
 //! Example of using the `SignerLayer` in the provider.
 
 use alloy::{
-    network::EthereumSigner,
+    network::{EthereumSigner, TransactionBuilder},
     node_bindings::Anvil,
     primitives::{address, b256, U256},
     providers::{Provider, ProviderBuilder},
@@ -18,6 +18,7 @@ async fn main() -> Result<()> {
 
     // Set up the wallets.
     let wallet: LocalWallet = anvil.keys()[0].clone().into();
+    let from = wallet.address();
 
     // Create a provider with the signer.
     let http = anvil.endpoint().parse()?;
@@ -26,14 +27,13 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(wallet))
         .on_client(RpcClient::new_http(http));
 
-    let tx = TransactionRequest {
-        nonce: Some(0),
-        value: Some(U256::from(100)),
-        to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
-        gas_price: Some(U256::from(20e9)),
-        gas: Some(U256::from(21000)),
-        ..Default::default()
-    };
+    let tx = TransactionRequest::default()
+        .with_nonce(0)
+        .with_from(from)
+        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into())
+        .with_value(U256::from(100))
+        .with_gas_price(U256::from(20e9))
+        .with_gas_limit(U256::from(21000));
 
     let builder = provider.send_transaction(tx).await?;
     let node_hash = *builder.tx_hash();

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<()> {
     // Create a provider with a signer and the network.
     let http = Http::<Client>::new(anvil.endpoint().parse()?);
     let provider = ProviderBuilder::new()
+        // Add the `SignerLayer` to the provider
         .signer(EthereumSigner::from(wallet))
         .provider(RootProvider::new(RpcClient::new(http, true)));
 

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -8,10 +8,11 @@ use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::request::TransactionRequest;
 use alloy_signer_wallet::LocalWallet;
 use alloy_transport_http::Http;
+use eyre::Result;
 use reqwest::Client;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH
     let anvil = Anvil::new().spawn();

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -1,0 +1,65 @@
+//! Example of using the `SignerLayer` in the provider.
+
+use alloy_network::EthereumSigner;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{address, b256, U256, U64};
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types::request::TransactionRequest;
+use alloy_signer_wallet::LocalWallet;
+use alloy_transport_http::Http;
+use reqwest::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().spawn();
+
+    // Set up the wallets.
+    let wallet: LocalWallet = anvil.keys()[0].clone().into();
+
+    // Create a provider with a signer and the network.
+    let http = Http::<Client>::new(anvil.endpoint().parse()?);
+    let provider = ProviderBuilder::new()
+        .signer(EthereumSigner::from(wallet))
+        .provider(RootProvider::new(RpcClient::new(http, true)));
+
+    let tx = TransactionRequest {
+        nonce: Some(U64::from(0)),
+        value: Some(U256::from(100)),
+        to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+        gas_price: Some(U256::from(20e9)),
+        gas: Some(U256::from(21000)),
+        ..Default::default()
+    };
+
+    let builder = provider.send_transaction(tx).await?;
+    let node_hash = *builder.tx_hash();
+
+    println!(
+        "Node hash matches expected hash: {}",
+        node_hash == b256!("eb56033eab0279c6e9b685a5ec55ea0ff8d06056b62b7f36974898d4fbb57e64")
+    );
+
+    let pending = builder.register().await?;
+    let pending_transaction_hash = *pending.tx_hash();
+
+    println!(
+        "Pending transaction hash matches node hash: {}",
+        pending_transaction_hash == node_hash
+    );
+
+    let transaction_hash = pending.await?;
+    assert_eq!(transaction_hash, node_hash);
+
+    println!("Transaction hash matches node hash: {}", transaction_hash == node_hash);
+
+    let receipt =
+        provider.get_transaction_receipt(transaction_hash).await.unwrap().expect("no receipt");
+    let receipt_hash = receipt.transaction_hash.expect("no receipt hash");
+
+    println!("Receipt hash matches node hash: {}", receipt_hash == node_hash);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

To add examples from `ethers-rs`: `middleware` (layers)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implements a subset of the examples from `ethers-rs`, specifically the `NonceManagerMiddleware` and the `SignerMiddleware`.

Currently not implemented as an example, due to the implementation missing in Alloy:

- `GasEscalatorMiddleware`
- `GasOracleMiddleware`
- `PolicyMiddleware`

Some examples are not implemented due to the builder pattern being used throughout all examples in Alloy.

`CustomMiddleware` has not been implemented yet as I think it likely will require some implementation work to be able to define a robust way of handling this. Users can refer to the existing implementations as a starting point.

I've decided to refer to these as `layers` rather than `ether-rs`'s `middleware`.