### PR TITLE
fix(general): use alloy namespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,41 +13,42 @@ repository = "https://github.com/alloy-rs/examples"
 publish = false
 
 [workspace.dependencies]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-rpc-engine-types = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer-aws = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer-gcp = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer-ledger = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer-trezor = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", default-features = false }
-
-alloy-core = { version = "0.6.4", default-features = false, features = ["std"] }
-alloy-dyn-abi = { version = "0.6.4", default-features = false, features = [
-    "std",
+alloy = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", features = [
+    # "dyn-abi",
+    # "json-abi",
+    # "json",
+    # "sol-types",
+    # "rlp",
+    # "serde",
+    "contract",
+    # "consensus",
+    # "eips",
+    "network",
+    # "genesis",
+    "node-bindings",
+    "providers",
+    "rpc",
+    # "json-rpc",
+    "rpc-client",
+    # "rpc-types",
+    "rpc-types-eth",
+    # "rpc-types-engine",
+    # "rpc-types-trace",
+    "signers",
+    # "signer-aws",
+    # "signer-gcp",
+    "signer-ledger",
+    "signer-trezor",
+    "signer-wallet",
+    "signer-mnemonic",
+    "signer-yubihsm",
+    # "transports",
+    "transport-http",
+    # "transport-ipc",
+    # "transport-ws",
+    # "pubsub",
 ] }
-alloy-json-abi = { version = "0.6.4", default-features = false, features = [
-    "std",
-] }
-alloy-primitives = { version = "0.6.4", default-features = false, features = [
-    "std",
-] }
+# TODO: sol! macro somehow requires this to be present
 alloy-sol-types = { version = "0.6.4", default-features = false, features = [
     "std",
 ] }

--- a/examples/big-numbers/Cargo.toml
+++ b/examples/big-numbers/Cargo.toml
@@ -11,8 +11,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dev-dependencies]
-alloy-core.workspace = true
-alloy-primitives.workspace = true
-alloy-serde.workspace = true
+alloy.workspace = true
 
 eyre.workspace = true

--- a/examples/big-numbers/examples/comparison_equivalence.rs
+++ b/examples/big-numbers/examples/comparison_equivalence.rs
@@ -1,6 +1,6 @@
 //! Example of comparison and equivalence of `U256` instances.
 
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 
 /// `U256` implements traits in `std::cmp`, that means `U256` instances
 /// can be easily compared using standard Rust operators.

--- a/examples/big-numbers/examples/conversion.rs
+++ b/examples/big-numbers/examples/conversion.rs
@@ -1,6 +1,6 @@
 //! Example of converting `U256` to native Rust types.
 
-use alloy_primitives::{utils::format_units, U256};
+use alloy::primitives::{utils::format_units, U256};
 use eyre::Result;
 
 /// `U256` provides useful conversion functions to enable transformation into native Rust types.

--- a/examples/big-numbers/examples/create_instances.rs
+++ b/examples/big-numbers/examples/create_instances.rs
@@ -1,6 +1,6 @@
 //! Example of creating instances of `U256` from strings and numbers.
 
-use alloy_primitives::{
+use alloy::primitives::{
     utils::{parse_units, ParseUnits},
     U256,
 };

--- a/examples/big-numbers/examples/math_operations.rs
+++ b/examples/big-numbers/examples/math_operations.rs
@@ -1,6 +1,6 @@
 //! Example of performing arithmetic operations with `U256`.
 
-use alloy_primitives::{utils::format_units, U256};
+use alloy::primitives::{utils::format_units, U256};
 use eyre::Result;
 use std::ops::{Div, Mul};
 

--- a/examples/big-numbers/examples/math_utilities.rs
+++ b/examples/big-numbers/examples/math_utilities.rs
@@ -1,6 +1,6 @@
 //! Example of using math utilities to handle big numbers in 'wei' units.
 
-use alloy_primitives::{
+use alloy::primitives::{
     utils::{format_units, parse_units},
     U256,
 };

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -11,16 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dev-dependencies]
-alloy-network.workspace = true
-alloy-node-bindings.workspace = true
-alloy-primitives.workspace = true
-alloy-provider.workspace = true
-alloy-rpc-client.workspace = true
-alloy-rpc-types.workspace = true
-alloy-signer = { workspace = true, features = ["eip712"] }
-alloy-signer-ledger.workspace = true
-alloy-signer-trezor.workspace = true
-alloy-signer-wallet = { workspace = true, features = ["mnemonic", "yubihsm"] }
+alloy.workspace = true
 alloy-sol-types.workspace = true
 
 eyre.workspace = true

--- a/examples/wallets/examples/ledger_signer.rs
+++ b/examples/wallets/examples/ledger_signer.rs
@@ -1,11 +1,12 @@
 //! Example of signing and sending a transaction using a Ledger device.
 
-use alloy_network::EthereumSigner;
-use alloy_primitives::{address, U256};
-use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_ledger::{HDPath, LedgerSigner};
+use alloy::{
+    network::EthereumSigner,
+    primitives::{address, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::ledger::{HDPath, LedgerSigner},
+};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/wallets/examples/mnemonic_signer.rs
+++ b/examples/wallets/examples/mnemonic_signer.rs
@@ -1,6 +1,6 @@
 //! Example of using `MnemonicBuilder` to access a wallet from a mnemonic phrase.
 
-use alloy_signer_wallet::{coins_bip39::English, MnemonicBuilder};
+use alloy::signers::wallet::{coins_bip39::English, MnemonicBuilder};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/wallets/examples/private_key_signer.rs
+++ b/examples/wallets/examples/private_key_signer.rs
@@ -1,12 +1,13 @@
 //! Example of using a local wallet to sign and broadcast a transaction on a local Anvil node.
 
-use alloy_network::EthereumSigner;
-use alloy_node_bindings::Anvil;
-use alloy_primitives::U256;
-use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_wallet::LocalWallet;
+use alloy::{
+    network::EthereumSigner,
+    node_bindings::Anvil,
+    primitives::U256,
+    providers::{Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::wallet::LocalWallet,
+};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/wallets/examples/sign_message.rs
+++ b/examples/wallets/examples/sign_message.rs
@@ -1,7 +1,6 @@
 //! Example of signing a message with a wallet.
 
-use alloy_signer::Signer;
-use alloy_signer_wallet::LocalWallet;
+use alloy::signers::{wallet::LocalWallet, Signer};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/wallets/examples/sign_permit_hash.rs
+++ b/examples/wallets/examples/sign_permit_hash.rs
@@ -1,9 +1,10 @@
 //! Example of signing a permit hash using a wallet.
 
-use alloy_primitives::{address, keccak256, U256};
-use alloy_signer::Signer;
-use alloy_signer_wallet::LocalWallet;
-use alloy_sol_types::{eip712_domain, sol, SolStruct};
+use alloy::{
+    primitives::{address, keccak256, U256},
+    signers::{wallet::LocalWallet, Signer},
+    sol_types::{eip712_domain, sol, SolStruct},
+};
 use eyre::Result;
 use serde::Serialize;
 
@@ -43,7 +44,7 @@ async fn main() -> Result<()> {
     let hash = permit.eip712_signing_hash(&domain);
 
     // Sign the hash asynchronously with the wallet.
-    let signature = wallet.sign_typed_data(&permit, &domain).await?;
+    let signature = wallet.sign_hash(&hash).await?;
 
     println!(
         "Recovered address matches wallet address: {:?}",

--- a/examples/wallets/examples/trezor_signer.rs
+++ b/examples/wallets/examples/trezor_signer.rs
@@ -1,11 +1,12 @@
 //! Example of signing and sending a transaction using a Trezor device.
 
-use alloy_network::EthereumSigner;
-use alloy_primitives::{address, U256};
-use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_trezor::{HDPath, TrezorSigner};
+use alloy::{
+    network::EthereumSigner,
+    primitives::{address, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::trezor::{HDPath, TrezorSigner},
+};
 use eyre::Result;
 
 #[tokio::main]

--- a/examples/wallets/examples/yubi_signer.rs
+++ b/examples/wallets/examples/yubi_signer.rs
@@ -1,13 +1,14 @@
 //! Example of signing and sending a transaction using a Yubi device.
 
-use alloy_network::EthereumSigner;
-use alloy_primitives::{address, U256};
-use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
-use alloy_rpc_types::request::TransactionRequest;
-use alloy_signer_wallet::{
-    yubihsm::{Connector, Credentials, UsbConfig},
-    YubiWallet,
+use alloy::{
+    network::EthereumSigner,
+    primitives::{address, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::{client::RpcClient, types::eth::request::TransactionRequest},
+    signers::wallet::{
+        yubihsm::{Connector, Credentials, UsbConfig},
+        YubiWallet,
+    },
 };
 use eyre::Result;
 


### PR DESCRIPTION
Supersedes #10 by not including the flattened directory structure as there is alignment on using the `alloy` namespace but not the earlier proposed directory structure.

Once merged will backport the change to the individual pending PRs.