### PR TITLE
Feature: transfer_eth example from ethers-rs

### DIFF
--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "examples-transactions"
+
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dev-dependencies]
+alloy.workspace = true
+
+eyre.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/examples/transactions/examples/transfer_eth.rs
+++ b/examples/transactions/examples/transfer_eth.rs
@@ -1,0 +1,52 @@
+use alloy::{
+    network::Ethereum,
+    node_bindings::Anvil,
+    primitives::U256,
+    providers::{Provider, RootProvider},
+    rpc::{client::RpcClient, types::eth::TransactionRequest},
+    transports::http::Http,
+};
+use eyre::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let anvil = Anvil::new().try_spawn()?;
+
+    let url = anvil.endpoint().parse().unwrap();
+    let http = Http::new(url);
+    let provider = RootProvider::<Ethereum, _>::new(RpcClient::new(http, true));
+
+    let accounts = provider.get_accounts().await?;
+    let from = accounts[0];
+    let to = accounts[1];
+
+    // craft the tx
+    let tx = TransactionRequest {
+        from: Some(from),
+        to: Some(to),
+        value: Some(U256::from(1000)),
+        ..Default::default()
+    };
+
+    let balance_before = provider.get_balance(from, None).await?;
+    let nonce_before = provider.get_transaction_count(from, None).await?;
+
+    // broadcast it via the eth_sendTransaction API
+    let builder = provider.send_transaction(tx).await?;
+
+    println!("{:#?}", &builder);
+
+    let balance_after = provider.get_balance(from, None).await?;
+    let nonce_after = provider.get_transaction_count(from, None).await?;
+
+    assert!(nonce_before < nonce_after);
+    assert!(balance_after < balance_before);
+
+    println!("Balance before: {balance_before}");
+    println!("Balance after: {balance_after}");
+
+    println!("Nonce before: {nonce_before}");
+    println!("Nonce after: {nonce_after}");
+
+    Ok(())
+}


### PR DESCRIPTION
I am not familiar much in working with workspaces so let me know if I have done anything wrongly. Also I have figured this all by looking in the tests so somethings might not be used in the best way possible.

This is the output I am getting:
```bash
PendingTransactionBuilder {
    config: PendingTransactionConfig {
        tx_hash: 0x006f3c41c2dfe86349371396ff676ae2c5d4a14b33bc893e94444e5049891517,
        confirmations: 0,
        timeout: None,
    },
    provider: RootProvider {
        client: RpcClient(
            RpcClientInner {
                transport: Http {
                    client: Client {
                        accepts: Accepts,
                        proxies: [
                            Proxy(
                                System(
                                    {},
                                ),
                                None,
                            ),
                        ],
                        referer: true,
                        default_headers: {
                            "accept": "*/*",
                        },
                    },
                    url: Url {
                        scheme: "http",
                        cannot_be_a_base: false,
                        username: "",
                        password: None,
                        host: Some(
                            Domain(
                                "localhost",
                            ),
                        ),
                        port: Some(
                            37793,
                        ),
                        path: "/",
                        query: None,
                        fragment: None,
                    },
                },
                is_local: true,
                id: 4,
            },
        ),
        ..
    },
}
Balance before: 10000000000000000000000
Balance after: 9999999978999999999000
Nonce before: 0
Nonce after: 1
```