### PR TITLE
fix: use `alloy::sol` instead of `alloy::sol_types::sol`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,6 @@ alloy = { git = "https://github.com/alloy-rs/alloy", rev = "fd8f065", features =
     "transport-ws",
     "pubsub",
 ] }
-# TODO: sol! macro somehow requires this to be present
-alloy-sol-types = { version = "0.6.4", default-features = false, features = [
-    "std",
-] }
-
 
 # async
 tokio = "1"

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true
-alloy-sol-types.workspace = true
 
 eyre.workspace = true
 reqwest.workspace = true

--- a/examples/wallets/examples/sign_permit_hash.rs
+++ b/examples/wallets/examples/sign_permit_hash.rs
@@ -3,7 +3,8 @@
 use alloy::{
     primitives::{address, keccak256, U256},
     signers::{wallet::LocalWallet, Signer},
-    sol_types::{eip712_domain, sol, SolStruct},
+    sol,
+    sol_types::{eip712_domain, SolStruct},
 };
 use eyre::Result;
 use serde::Serialize;


### PR DESCRIPTION
`alloy::sol` overrides the `alloy_sol_types` import with `alloy::sol_types`, and should be used instead of the inner `alloy::sol_types::sol`.