### PR TITLE
Add Github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  feature-checks:
+  checks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -26,9 +26,21 @@ jobs:
       - name: cargo hack
         run: cargo hack check --feature-powerset --depth 2
 
+  examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: |
+          cargo run --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --example
+
   clippy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@clippy
@@ -41,7 +53,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,22 @@ jobs:
       - name: Run examples
         run: |
           # Get the list of runable examples
-          examples="$(
+          export examples="$(
             cargo run --example 2>&1 \
             | grep -E '^ ' \
             | grep -v \
+            -e 'trezor_signer' \
+            -e 'ledger_signer' \
             -e 'yubi_signer' \
+            -e 'ipc' \
             -e 'ws' \
             -e 'ws_auth' \
+            -e 'query_logs' \
             | xargs -n1 echo
           )"
+
+          # Log the examples to run
+          echo "Running the following examples: $examples"
 
           # Run the examples
           echo "$examples" | xargs -n1 cargo run --example  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: |
+      - name: Run examples
+        run: |
           # Get the list of runable examples
           examples="$(
             cargo run --example 2>&1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
   examples:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -36,7 +36,19 @@ jobs:
         with:
           cache-on-failure: true
       - run: |
-          cargo run --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --example
+          # Get the list of runable examples
+          examples="$(
+            cargo run --example 2>&1 \
+            | grep -E '^ ' \
+            | grep -v \
+            -e 'yubi_signer' \
+            -e 'ws' \
+            -e 'ws_auth' \
+            | xargs -n1 echo
+          )"
+
+          # Run the examples
+          echo "$examples" | xargs -n1 cargo run --example  
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  feature-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo hack
+        run: cargo hack check --feature-powerset --depth 2
+
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,61 @@
+# Runs `cargo update` periodically.
+
+name: Update Dependencies
+
+on:
+  schedule:
+    # Run weekly
+    - cron: "0 0 * * SUN"
+  workflow_dispatch:
+    # Needed so we can run it manually
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BRANCH: cargo-update
+  TITLE: "chore(deps): weekly `cargo update`"
+  BODY: |
+    Automation to keep dependencies in `Cargo.lock` current.
+
+    <details><summary><strong>cargo update log</strong></summary>
+    <p>
+
+    ```log
+    $cargo_update_log
+    ```
+
+    </p>
+    </details>
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: cargo update
+        # Remove first line that always just says "Updating crates.io index"
+        run: cargo update --color never 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+
+      - name: craft commit message and PR body
+        id: msg
+        run: |
+          export cargo_update_log="$(cat cargo_update.log)"
+
+          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
+          printf "$TITLE\n\n$cargo_update_log\n" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" | envsubst >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: ./Cargo.lock
+          commit-message: ${{ steps.msg.outputs.commit_message }}
+          title: ${{ env.TITLE }}
+          body: ${{ steps.msg.outputs.body }}
+          branch: ${{ env.BRANCH }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
-# Runs `cargo update` periodically.
+# Runs weeky `cargo update` to keep dependencies current.
 
-name: Update Dependencies
+name: Update dependencies
 
 on:
   schedule:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   update:
-    name: Update
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -20,6 +20,20 @@ jobs:
         with:
           cache-on-failure: true
       - run: |
+          # Get the list of runable examples
+          examples="$(
+            cargo run --example 2>&1 \
+            | grep -E '^ ' \
+            | grep -v \
+            -e 'yubi_signer' \
+            -e 'ws' \
+            -e 'ws_auth' \
+            | xargs -n1 echo
+          )"
+
+          # Run the examples with the current version of Alloy
+          echo "$examples" | xargs -n1 cargo run --example
+
           # Fetch the latest commit hash of the main branch from the alloy repository
           latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
             | grep refs/heads/main \
@@ -32,6 +46,6 @@ jobs:
           # Update to the latest commit
           cargo update
 
-          # Run the examples
-          cargo run --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --example
+          # Run the examples with the latest version of Alloy
+          echo "$examples" | xargs -n1 cargo run --example
         

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,37 @@
+# Runs Alloy integration tests daily to ensure compatibility with the latest version of Alloy.
+
+name: Alloy integration test
+
+on:
+  schedule:
+    # Run daily
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    # Needed so we can run it manually
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: |
+          # Fetch the latest commit hash of the main branch from the alloy repository
+          latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
+            | grep refs/heads/main \
+            | cut -f 1)
+
+          # Use the commit hash to update the rev in Cargo.toml
+          sed -i 's/\(alloy = { git = "https:\/\/github.com\/alloy-rs\/alloy", rev = "\)[^"]*/\1'"$latest_alloy_commit"'/' \
+          Cargo.toml
+
+          # Update to the latest commit
+          cargo update
+
+          # Run the examples
+          cargo run --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --example
+        

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,10 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: |
+      - name: Run examples
+        run: |
           # Get the list of runable examples
           examples="$(
             cargo run --example 2>&1 \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,12 +36,18 @@ jobs:
             | xargs -n1 echo
           )"
 
-          # Log the examples to run
-          echo -e "Running the following examples:\n$examples"
-
           # Run the examples with the current version of Alloy
           for example in $examples; do
+            echo "Running: $example ..."
+            
             cargo run --example $example --quiet 1>/dev/null
+
+            if [ $? -ne 0 ]; then
+              echo "Failed to run: $example"
+              exit 1
+            else
+              echo "Successfully ran: $example"
+            fi
           done
 
           # Fetch the latest commit hash of the main branch from the Alloy repository
@@ -58,6 +64,15 @@ jobs:
 
           # Run the examples with the latest version of Alloy
           for example in $examples; do
+            echo "Running: $example ..."
+
             cargo run --example $example --quiet 1>/dev/null
+
+            if [ $? -ne 0 ]; then
+              echo "Failed to run: $example"
+              exit 1
+            else
+              echo "Successfully ran: $example"
+            fi
           done
         

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,8 +38,6 @@ jobs:
 
           # Run the examples with the current version of Alloy
           for example in $examples; do
-            echo "Running: $example ..."
-            
             cargo run --example $example --quiet 1>/dev/null
 
             if [ $? -ne 0 ]; then
@@ -64,8 +62,6 @@ jobs:
 
           # Run the examples with the latest version of Alloy
           for example in $examples; do
-            echo "Running: $example ..."
-
             cargo run --example $example --quiet 1>/dev/null
 
             if [ $? -ne 0 ]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,15 +33,16 @@ jobs:
             -e 'ipc' \
             -e 'ws' \
             -e 'ws_auth' \
-            -e 'query_logs' \
             | xargs -n1 echo
           )"
 
           # Log the examples to run
-          echo "Running the following examples: $examples"
+          echo -e "Running the following examples:\n$examples"
 
           # Run the examples with the current version of Alloy
-          echo "$examples" | xargs -n1 cargo run --example
+          for example in $examples; do
+            cargo run --example $example --quiet 1>/dev/null
+          done
 
           # Fetch the latest commit hash of the main branch from the Alloy repository
           export latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
@@ -56,5 +57,7 @@ jobs:
           cargo update
 
           # Run the examples with the latest version of Alloy
-          echo "$examples" | xargs -n1 cargo run --example
+          for example in $examples; do
+            cargo run --example $example --quiet 1>/dev/null
+          done
         

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,21 +23,28 @@ jobs:
       - name: Run examples
         run: |
           # Get the list of runable examples
-          examples="$(
+          export examples="$(
             cargo run --example 2>&1 \
             | grep -E '^ ' \
             | grep -v \
+            -e 'trezor_signer' \
+            -e 'ledger_signer' \
             -e 'yubi_signer' \
+            -e 'ipc' \
             -e 'ws' \
             -e 'ws_auth' \
+            -e 'query_logs' \
             | xargs -n1 echo
           )"
+
+          # Log the examples to run
+          echo "Running the following examples: $examples"
 
           # Run the examples with the current version of Alloy
           echo "$examples" | xargs -n1 cargo run --example
 
-          # Fetch the latest commit hash of the main branch from the alloy repository
-          latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
+          # Fetch the latest commit hash of the main branch from the Alloy repository
+          export latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
             | grep refs/heads/main \
             | cut -f 1)
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+# Runs `clippy` and `cargo fmt` checks.
+
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -Dwarnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,13 @@ jobs:
             -e 'ipc' \
             -e 'ws' \
             -e 'ws_auth' \
-            -e 'query_logs' \
             | xargs -n1 echo
           )"
 
           # Log the examples to run
-          echo "Running the following examples: $examples"
+          echo -e "Running the following examples:\n$examples"
 
           # Run the examples
-          echo "$examples" | xargs -n1 cargo run --example
+          for example in $examples; do
+            cargo run --example $example --quiet 1>/dev/null
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
-name: CI
+# Runs build checks and examples.
+
+name: Test
 
 on:
   push:
@@ -57,27 +59,4 @@ jobs:
           echo "Running the following examples: $examples"
 
           # Run the examples
-          echo "$examples" | xargs -n1 cargo run --example  
-
-  clippy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
-        env:
-          RUSTFLAGS: -Dwarnings
-
-  fmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - run: cargo fmt --all --check
+          echo "$examples" | xargs -n1 cargo run --example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,16 @@ jobs:
             | xargs -n1 echo
           )"
 
-          # Log the examples to run
-          echo -e "Running the following examples:\n$examples"
-
           # Run the examples
           for example in $examples; do
+            echo "Running: $example ..."
+
             cargo run --example $example --quiet 1>/dev/null
+
+            if [ $? -ne 0 ]; then
+              echo "Failed to run: $example"
+              exit 1
+            else
+              echo "Successfully ran: $example"
+            fi
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,6 @@ jobs:
 
           # Run the examples
           for example in $examples; do
-            echo "Running: $example ..."
-
             cargo run --example $example --quiet 1>/dev/null
 
             if [ $? -ne 0 ]; then

--- a/examples/anvil/examples/fork_anvil.rs
+++ b/examples/anvil/examples/fork_anvil.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH
-    let anvil = Anvil::new().fork("https://eth.llamarpc.com").try_spawn()?;
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
 
     println!("Anvil running at `{}`", anvil.endpoint());
 

--- a/examples/contracts/examples/generate.rs
+++ b/examples/contracts/examples/generate.rs
@@ -14,7 +14,7 @@ sol!(
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH
-    let anvil = Anvil::new().fork("https://eth.llamarpc.com").try_spawn()?;
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
 
     // Create a provider.
     let provider =

--- a/examples/providers/examples/builder.rs
+++ b/examples/providers/examples/builder.rs
@@ -12,13 +12,15 @@ use eyre::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Setup the HTTP transport which is consumed by the RPC client
-    let anvil = Anvil::new().spawn();
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
 
     let pk = &anvil.keys()[0];
     let from = anvil.addresses()[0];
     let signer = Wallet::from(pk.to_owned());
 
+    // Setup the HTTP transport which is consumed by the RPC client
     let rpc_client = RpcClient::new_http(anvil.endpoint().parse().unwrap());
     let provider_with_signer = ProviderBuilder::new()
         .signer(EthereumSigner::from(signer))

--- a/examples/subscriptions/examples/event_multiplexer.rs
+++ b/examples/subscriptions/examples/event_multiplexer.rs
@@ -36,7 +36,10 @@ sol!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().block_time(1).spawn();
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
+
     let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
     let provider = RootProvider::<Ethereum, _>::new(RpcClient::connect_pubsub(ws).await?);
 

--- a/examples/subscriptions/examples/subscribe_blocks.rs
+++ b/examples/subscriptions/examples/subscribe_blocks.rs
@@ -8,7 +8,10 @@ use futures_util::{stream, StreamExt};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().block_time(1).spawn();
+    // Spin up a local Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
+
     let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
     let provider = RootProvider::<Ethereum, _>::new(RpcClient::connect_pubsub(ws).await?);
 

--- a/examples/subscriptions/examples/watch_contract_event.rs
+++ b/examples/subscriptions/examples/watch_contract_event.rs
@@ -28,7 +28,8 @@ sol!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().block_time(1).spawn();
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
+
     let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
     let provider = RootProvider::<Ethereum, _>::new(RpcClient::connect_pubsub(ws).await?);
 

--- a/examples/transactions/examples/gas_price_usd.rs
+++ b/examples/transactions/examples/gas_price_usd.rs
@@ -22,7 +22,10 @@ sol!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().fork("https://eth.merkle.io").spawn();
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
+
     let url = anvil.endpoint().parse().unwrap();
     let provider = HttpProvider::<Ethereum>::new_http(url);
 

--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -15,7 +15,10 @@ use reqwest::Url;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().fork("https://eth.merkle.io").spawn();
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
+
     let provider =
         HttpProvider::<Ethereum>::new_http("https://eth.merkle.io".parse::<Url>().unwrap());
 

--- a/examples/transactions/examples/trace_transaction.rs
+++ b/examples/transactions/examples/trace_transaction.rs
@@ -14,7 +14,10 @@ use eyre::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().fork("https://eth.merkle.io").spawn();
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
+
     let url = anvil.endpoint().parse().unwrap();
     let provider = HttpProvider::<Ethereum>::new_http(url);
     let hash = fixed_bytes!("97a02abf405d36939e5b232a5d4ef5206980c5a6661845436058f30600c52df7"); // Hash of the tx we want to trace

--- a/examples/transactions/examples/transfer_erc20.rs
+++ b/examples/transactions/examples/transfer_erc20.rs
@@ -15,7 +15,10 @@ sol!(ERC20Example, "examples/contracts/ERC20Example.json");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().fork("https://eth.merkle.io").spawn();
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
+
     let url = anvil.endpoint().parse().unwrap();
     let provider = HttpProvider::<Ethereum>::new_http(url);
 

--- a/examples/transactions/examples/transfer_eth.rs
+++ b/examples/transactions/examples/transfer_eth.rs
@@ -11,7 +11,10 @@ use eyre::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let anvil = Anvil::new().fork("https://eth.merkle.io").spawn();
+    // Spin up a forked Anvil node.
+    // Ensure `anvil` is available in $PATH
+    let anvil = Anvil::new().fork("https://eth.merkle.io").try_spawn()?;
+
     let url = anvil.endpoint().parse().unwrap();
     let provider = HttpProvider::<Ethereum>::new_http(url);
 


### PR DESCRIPTION
Closes #19

Adds multiple Github workflows:

- `lint` (clippy and fmt)
- `test` (runs a build check and the examples)
- `integration` (runs daily against current pinned version of `alloy` and latest commit on main of `alloy`)
- `dependencies` (runs weekly, opens a ticket with outdated dependencies and proposed new ones)

Does not yet have integration set up with Discord webhooks