### PR TITLE
[Fix] Rename `ManagedNonceLayer` to `NonceManagerLayer`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo +nightly clippy --examples --all-features
         env:
           RUSTFLAGS: -Dwarnings
 
@@ -36,4 +36,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: cargo +nightly fmt --all --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,31 @@ unused_rounding = "warn"
 useless_let_if_seq = "warn"
 uninlined_format_args = "warn"
 
+# These are nursery lints which have findings. Allow them for now. Some are not
+# quite mature enough for use in our codebase and some we don't really want.
+# Explicitly listing should make it easier to fix in the future.
+as_ptr_cast_mut = "allow"
+cognitive_complexity = "allow"
+collection_is_never_read = "allow"
+debug_assert_with_mut_call = "allow"
+empty_line_after_doc_comments = "allow"
+fallible_impl_from = "allow"
+future_not_send = "allow"
+iter_on_single_items = "allow"
+missing_const_for_fn = "allow"
+needless_collect = "allow"
+non_send_fields_in_send_ty = "allow"
+option_if_let_else = "allow"
+redundant_pub_crate = "allow"
+significant_drop_in_scrutinee = "allow"
+significant_drop_tightening = "allow"
+string_lit_as_bytes = "allow"
+type_repetition_in_bounds = "allow"
+unnecessary_struct_initialization = "allow"
+use_self = "allow"
+
 [workspace.dependencies]
-alloy = { git = "https://github.com/alloy-rs/alloy", rev = "f7333c4", features = [
+alloy = { git = "https://github.com/alloy-rs/alloy", rev = "66fa192", features = [
     # "dyn-abi",
     # "json-abi",
     # "json",
@@ -102,10 +125,10 @@ tokio = "1"
 eyre = "0.6.12"
 
 [patch.crates-io]
-alloy-core = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-core = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "525a233" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "525a233" }

--- a/examples/layers/examples/nonce_layer.rs
+++ b/examples/layers/examples/nonce_layer.rs
@@ -1,10 +1,10 @@
-//! Example of using the `ManagedNonceLayer` in the provider.
+//! Example of using the `NonceManagerLayer` in the provider.
 
 use alloy::{
     network::{EthereumSigner, TransactionBuilder},
     node_bindings::Anvil,
     primitives::{address, U256},
-    providers::{layers::ManagedNonceLayer, Provider, ProviderBuilder},
+    providers::{layers::NonceManagerLayer, Provider, ProviderBuilder},
     rpc::{client::RpcClient, types::eth::request::TransactionRequest},
     signers::wallet::LocalWallet,
 };
@@ -35,10 +35,10 @@ async fn main() -> Result<()> {
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
-        // Add the `ManagedNonceLayer` to the provider.
+        // Add the `NonceManagerLayer` to the provider.
         // It is generally recommended to use the `.with_recommended_layers()` method, which
-        // includes the `ManagedNonceLayer`.
-        .layer(ManagedNonceLayer)
+        // includes the `NonceManagerLayer`.
+        .layer(NonceManagerLayer)
         .signer(EthereumSigner::from(signer))
         .on_client(RpcClient::new_http(rpc_url));
 

--- a/examples/layers/examples/recommended_layers.rs
+++ b/examples/layers/examples/recommended_layers.rs
@@ -1,4 +1,4 @@
-//! Example of using the `ManagedNonceLayer` in the provider.
+//! Example of using the `.with_recommended_layers()` method in the provider.
 
 use alloy::{
     network::{EthereumSigner, TransactionBuilder},
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
-        // Adds the `GasEstimatorLayer` and the `ManagedNonceLayer` layers.
+        // Adds the `GasEstimatorLayer` and the `NonceManagerLayer` layers.
         .with_recommended_layers()
         // Alternatively, you can add the layers individually:
         // .with_gas_estimation()
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
         .on_client(RpcClient::new_http(rpc_url));
 
     // Create an EIP-1559 type transaction.
-    // Notice that the `nonce` field is set by the `ManagedNonceLayer`.
+    // Notice that the `nonce` field is set by the `NonceManagerLayer`.
     // Notice that without the `GasEstimatorLayer`, you need to set the gas related fields.
     let tx = TransactionRequest::default()
         .with_from(alice)

--- a/examples/layers/examples/signer_layer.rs
+++ b/examples/layers/examples/signer_layer.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     // Create a legacy type transaction.
     let tx = TransactionRequest::default()
         .with_from(alice)
-        // Notice that without the `ManagedNonceLayer`, you need to manually set the nonce field.
+        // Notice that without the `NonceManagerLayer`, you need to manually set the nonce field.
         .with_nonce(0)
         .with_to(vitalik.into())
         .with_value(U256::from(100))

--- a/examples/providers/Cargo.toml
+++ b/examples/providers/Cargo.toml
@@ -15,10 +15,10 @@ workspace = true
 [dev-dependencies]
 alloy.workspace = true
 # Temp dependency fix to enable relevant features - Ref: https://github.com/alloy-rs/examples/pull/3#discussion_r1537842062
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "f7333c4", features = [
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "66fa192", features = [
     "pubsub",
 ] }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "f7333c4", features = [
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "66fa192", features = [
     "pubsub",
     "ws",
 ] }

--- a/examples/subscriptions/Cargo.toml
+++ b/examples/subscriptions/Cargo.toml
@@ -15,11 +15,11 @@ workspace = true
 [dev-dependencies]
 alloy.workspace = true
 # Temp fix for enabling features. Ref: https://github.com/alloy-rs/examples/pull/3/#discussion_r1537842062
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "f7333c4", features = [
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "66fa192", features = [
     "pubsub",
     "ws",
 ] }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "f7333c4", features = [
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "66fa192", features = [
     "pubsub",
 ] }
 # alloy-contract.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->



## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #35 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Updates to latest Alloy / Alloy Core commit, renames `ManagedNonceLayer` to `NonceManagerLayer`.
Adds small comment fix and enhance Clippy linting rules.

## PR Checklist

- [x] Added Documentation
- [ ] Breaking changes