### PR TITLE
fix(`trace_call`): use another address with eth balance for `trace_call` example

### DIFF
--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let provider = ProviderBuilder::new().on_reqwest_http(rpc_url)?;
 
     // Create two users, Alice and Bob.
-    let alice = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    let alice = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let bob = address!("70997970C51812dc3A010C7d01b50e0d17dc79C8");
 
     // Create a transaction to send 100 wei from Alice to Bob.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

the trace call example `from` address had no eth, which was causing the test to fail.

## Solution

Use an address with eth, which makes the test pass.

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes