### PR TITLE
Fixing "run all examples" command for macOS (Contributing page)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ cargo run --example 2>&1 \
    -e 'ws' \
    -e 'ws_auth' \
    -e 'connect_builtin' \
-   | xargs -I {} sh -c 'if cargo run --example {} --quiet 1>/dev/null; then \
+   | xargs -S1024 -I {} sh -c 'if cargo run --example {} --quiet 1>/dev/null; then \
         echo "Successfully ran: {}"; \
       else \
         echo "Failed to run: {}"; \


### PR DESCRIPTION
While running this on my machine (Apple silicon mac) I got this: 
`xargs: command line cannot be assembled, too long`

On macOS (and possibly other compatible systems), there is a limit on the size of arguments that can be passed using the `-I` flag. From the manual page (`man xargs`):
```
     -S replsize
             Specify the amount of space (in bytes) that -I can use for
             replacements.  The default for replsize is 255.
```

So, bumping this number up (e.g. adding `-S1024`) can resolve this problem.

This change shouldn't affect other architectures, but It would be great if the reviewer could validate this on another setup different than mine.

## Motivation

Smoother dev contributing experience (just copy n' paste)

## Solution

Adding a flag to the To run all (runnable) examples, specifically to the `xargs` part of the command.
`xargs -S1024 -I {} sh -c 'if cargo run --example {} --quiet 1>/dev/null;`

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes