### PR TITLE
add comment: how to set up signer from private key

### DIFF
--- a/examples/wallets/examples/private_key_signer.rs
+++ b/examples/wallets/examples/private_key_signer.rs
@@ -18,6 +18,8 @@ async fn main() -> Result<()> {
 
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
+    // If you want to set up signer from your own private key string, you can do so like this.
+    //let signer: LocalWallet = "<YOUR_PRIVATE_KEY>".parse().unwrap();
     let alice = signer.address();
 
     // Create a provider with the signer.


### PR DESCRIPTION
Add comments and sample code that how to set up signer from private key, users can set singer on the testnet such as sepolia instead of the local anvil environment.