### PR TITLE
add comment: risk warning and how to set up signer from private key

### DIFF
--- a/examples/wallets/examples/private_key_signer.rs
+++ b/examples/wallets/examples/private_key_signer.rs
@@ -18,6 +18,9 @@ async fn main() -> Result<()> {
 
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
+    // [RISK WARNING! Writing a private key in the code file is insecure behavior.]
+    // The following code is for testing only. Set up signer from private key, be aware of danger.
+    // let signer: LocalWallet = "<THE_PRIVATE_KEY>".parse().unwrap();
     let alice = signer.address();
 
     // Create a provider with the signer.


### PR DESCRIPTION
As the name of the example file, some people may need this operation to implement some quick testing or automated procedures. But security is really important, so I put risk warnings in prominent places to increase people's security awareness.