### PR TITLE
chore(transactions) use `send_tx_envelope` rather than manually encoding and calling `send_raw_transaction`

### DIFF
--- a/examples/transactions/examples/send_raw_transaction.rs
+++ b/examples/transactions/examples/send_raw_transaction.rs
@@ -1,7 +1,7 @@
 //! Example of signing, encoding and sending a raw transaction using a wallet.
 
 use alloy::{
-    network::{eip2718::Encodable2718, EthereumSigner, TransactionBuilder},
+    network::{EthereumSigner, TransactionBuilder},
     node_bindings::Anvil,
     primitives::U256,
     providers::{Provider, ProviderBuilder},
@@ -39,14 +39,13 @@ async fn main() -> Result<()> {
         .with_max_priority_fee_per_gas(1_000_000_000)
         .with_max_fee_per_gas(20_000_000_000);
 
-    // Build the transaction using the `EthereumSigner` with the provided signer.
+    // Build and sign the transaction using the `EthereumSigner` with the provided signer.
     let tx_envelope = tx.build(&signer).await?;
 
-    // Encode the transaction using EIP-2718 encoding.
-    let tx_encoded = tx_envelope.encoded_2718();
-
     // Send the raw transaction and retrieve the transaction receipt.
-    let receipt = provider.send_raw_transaction(&tx_encoded).await?.get_receipt().await?;
+    // [Provider::send_tx_envelope] is a convenience method that encodes the transaction using
+    // EIP-2718 encoding and broadcasting it to the network using [Provider::send_raw_transaction].
+    let receipt = provider.send_tx_envelope(tx_envelope).await?.get_receipt().await?;
 
     println!("Sent transaction: {}", receipt.transaction_hash);
 

--- a/examples/transactions/examples/send_raw_transaction.rs
+++ b/examples/transactions/examples/send_raw_transaction.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
 
     // Send the raw transaction and retrieve the transaction receipt.
     // [Provider::send_tx_envelope] is a convenience method that encodes the transaction using
-    // EIP-2718 encoding and broadcasting it to the network using [Provider::send_raw_transaction].
+    // EIP-2718 encoding and broadcasts it to the network using [Provider::send_raw_transaction].
     let receipt = provider.send_tx_envelope(tx_envelope).await?.get_receipt().await?;
 
     println!("Sent transaction: {}", receipt.transaction_hash);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Addresses: https://github.com/alloy-rs/alloy/issues/283#issuecomment-2161061664

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added explanatory snippet explaining convenience method

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes