### PR TITLE
fix(general): only set `.with_from field` if required

### DIFF
--- a/examples/fillers/examples/gas_filler.rs
+++ b/examples/fillers/examples/gas_filler.rs
@@ -19,10 +19,6 @@ async fn main() -> Result<()> {
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create two users, Alice and Vitalik.
-    let alice = signer.address();
-    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
@@ -33,9 +29,9 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Create an EIP-1559 type transaction.
+    // Build an EIP-1559 type transaction to send 100 wei to Vitalik.
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(vitalik)
         .with_value(U256::from(100))
         // Notice that without the `NonceFiller`, you need to set `nonce` field.

--- a/examples/fillers/examples/nonce_filler.rs
+++ b/examples/fillers/examples/nonce_filler.rs
@@ -28,10 +28,6 @@ async fn main() -> Result<()> {
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create two users, Alice and Vitalik.
-    let alice = signer.address();
-    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
@@ -42,9 +38,9 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Create an EIP-1559 type transaction.
+    // Build an EIP-1559 type transaction to send 100 wei to Vitalik.
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(vitalik)
         .with_value(U256::from(100))
         // Notice that without the `GasFiller`, you need to set the gas related fields.

--- a/examples/fillers/examples/recommended_fillers.rs
+++ b/examples/fillers/examples/recommended_fillers.rs
@@ -19,10 +19,6 @@ async fn main() -> Result<()> {
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create two users, Alice and Vitalik.
-    let alice = signer.address();
-    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
@@ -31,12 +27,12 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a EIP-1559 type transaction.
+    // Build an EIP-1559 type transaction to send 100 wei to Vitalik.
     // Notice that the `nonce` field is set by the `NonceFiller`.
     // Notice that the gas related fields are set by the `GasFiller`.
     // Notice that the `chain_id` field is set by the `ChainIdFiller`.
-    let tx =
-        TransactionRequest::default().with_from(alice).with_to(vitalik).with_value(U256::from(100));
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    let tx = TransactionRequest::default().with_to(vitalik).with_value(U256::from(100));
 
     // Send the transaction, the nonce (0) is automatically managed by the provider.
     let builder = provider.send_transaction(tx.clone()).await?;

--- a/examples/fillers/examples/signer_filler.rs
+++ b/examples/fillers/examples/signer_filler.rs
@@ -19,10 +19,6 @@ async fn main() -> Result<()> {
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create two users, Alice and Vitalik.
-    let alice = signer.address();
-    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
     let provider = ProviderBuilder::new()
@@ -31,12 +27,12 @@ async fn main() -> Result<()> {
         .on_http(rpc_url);
 
     // Build a legacy type transaction to send 100 wei to Vitalik.
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let tx = TransactionRequest::default()
-        .with_from(alice)
-        // Notice that without the `NonceFiller`, you need to manually set the nonce field.
-        .with_nonce(0)
         .with_to(vitalik)
         .with_value(U256::from(100))
+        // Notice that without the `NonceFiller`, you need to manually set the nonce field.
+        .with_nonce(0)
         // Notice that without the `GasFiller`, you need to set the gas related fields.
         .with_gas_price(20_000_000_000)
         .with_gas_limit(21_000);

--- a/examples/providers/examples/builder.rs
+++ b/examples/providers/examples/builder.rs
@@ -31,8 +31,7 @@ async fn main() -> Result<()> {
         .on_http(rpc_url);
 
     // Create a transaction.
-    let tx =
-        TransactionRequest::default().with_from(alice).with_to(bob).with_value(U256::from(100));
+    let tx = TransactionRequest::default().with_to(bob).with_value(U256::from(100));
 
     // Send the transaction and wait for the broadcast.
     let pending_tx = provider.send_transaction(tx).await?;

--- a/examples/transactions/examples/send_eip1559_transaction.rs
+++ b/examples/transactions/examples/send_eip1559_transaction.rs
@@ -24,8 +24,8 @@ async fn main() -> Result<()> {
     let bob = anvil.addresses()[1];
 
     // Build a transaction to send 100 wei from Alice to Bob.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(bob)
         .with_nonce(0)
         .with_chain_id(anvil.chain_id())

--- a/examples/transactions/examples/send_eip4844_transaction.rs
+++ b/examples/transactions/examples/send_eip4844_transaction.rs
@@ -29,10 +29,10 @@ async fn main() -> Result<()> {
     let sidecar = sidecar.build()?;
 
     // Build a transaction to send the sidecar from Alice to Bob.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let gas_price = provider.get_gas_price().await?;
     let eip1559_est = provider.estimate_eip1559_fees(None).await?;
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(bob)
         .with_nonce(0)
         .with_max_fee_per_blob_gas(gas_price)

--- a/examples/transactions/examples/send_legacy_transaction.rs
+++ b/examples/transactions/examples/send_legacy_transaction.rs
@@ -24,8 +24,8 @@ async fn main() -> Result<()> {
     let bob = anvil.addresses()[1];
 
     // Build a transaction to send 100 wei from Alice to Bob.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(bob)
         .with_nonce(0)
         .with_value(U256::from(100))

--- a/examples/transactions/examples/send_private_transaction.rs
+++ b/examples/transactions/examples/send_private_transaction.rs
@@ -38,13 +38,10 @@ async fn main() -> Result<()> {
     // Create a signer from a random wallet.
     let signer = LocalWallet::random();
 
-    // Create two users, Alice and Bob.
-    let alice = signer.address();
-    let bob = LocalWallet::random().address();
-
     // Build a transaction to send 100 wei from Alice to Bob.
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let bob = LocalWallet::random().address();
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(bob)
         .with_nonce(0)
         .with_chain_id(1)

--- a/examples/transactions/examples/send_raw_transaction.rs
+++ b/examples/transactions/examples/send_raw_transaction.rs
@@ -29,8 +29,8 @@ async fn main() -> Result<()> {
     let bob = anvil.addresses()[1];
 
     // Build a transaction to send 100 wei from Alice to Bob.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(bob)
         .with_nonce(0)
         .with_chain_id(anvil.chain_id())

--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -14,13 +14,11 @@ async fn main() -> Result<()> {
     let rpc_url = "https://eth.merkle.io".parse()?;
     let provider = ProviderBuilder::new().on_http(rpc_url);
 
-    // Create two users, Alice and Bob.
-    let alice = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-    let bob = address!("70997970C51812dc3A010C7d01b50e0d17dc79C8");
-
-    // Build a transaction to send 100 wei from Alice to Bob.
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    let alice = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let tx =
-        TransactionRequest::default().with_from(alice).with_to(bob).with_value(U256::from(100));
+        TransactionRequest::default().with_from(alice).with_to(vitalik).with_value(U256::from(100));
 
     // Trace the transaction on top of the latest block.
     let trace_type = [TraceType::Trace];

--- a/examples/transactions/examples/transfer_eth.rs
+++ b/examples/transactions/examples/transfer_eth.rs
@@ -22,10 +22,6 @@ async fn main() -> Result<()> {
     // Set up wallet from the first default Anvil account (Alice).
     let wallet: LocalWallet = anvil.keys()[0].clone().into();
 
-    // Create two users, Alice and Bob.
-    let alice = wallet.address();
-    let bob = anvil.addresses()[1];
-
     // Create a provider with a signer and the network.
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
@@ -33,8 +29,9 @@ async fn main() -> Result<()> {
         .on_http(rpc_url);
 
     // Build a transaction to send 100 wei from Alice to Bob.
-    let tx =
-        TransactionRequest::default().with_from(alice).with_to(bob).with_value(U256::from(100));
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let bob = anvil.addresses()[1];
+    let tx = TransactionRequest::default().with_to(bob).with_value(U256::from(100));
 
     // Send the transaction and listen for the transaction to be included.
     let tx_hash = provider.send_transaction(tx).await?.watch().await?;

--- a/examples/transactions/examples/with_access_list.rs
+++ b/examples/transactions/examples/with_access_list.rs
@@ -26,28 +26,20 @@ async fn main() -> Result<()> {
     let provider =
         ProviderBuilder::new().with_recommended_fillers().on_builtin(&anvil.endpoint()).await?;
 
-    // Create two users, Alice and Bob.
-    let alice = anvil.addresses()[0];
-    let bob = anvil.addresses()[1];
-
     // Deploy the `SimpleStorage` contract.
+    let alice = anvil.addresses()[0];
     let contract_address = SimpleStorage::deploy_builder(provider.clone(), "initial".to_string())
         .from(alice)
         .deploy()
         .await?;
     let contract = SimpleStorage::new(contract_address, provider.clone());
 
-    // Build a transaction to set the values.
+    // Build a transaction to set the values of the contract.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let set_value_call = contract.setValues("hello".to_string(), "world".to_string());
     let calldata = set_value_call.calldata().to_owned();
-
-    let eip1559_fees = provider.estimate_eip1559_fees(None).await?;
-    let tx = TransactionRequest::default()
-        .from(bob)
-        .to(contract_address)
-        .input(calldata.into())
-        .max_fee_per_gas(eip1559_fees.max_fee_per_gas)
-        .max_priority_fee_per_gas(eip1559_fees.max_priority_fee_per_gas);
+    let bob = anvil.addresses()[1];
+    let tx = TransactionRequest::default().from(bob).to(contract_address).input(calldata.into());
 
     // Create an access list for the transaction.
     let access_list_with_gas_used = provider.create_access_list(&tx).await?;

--- a/examples/wallets/examples/keystore_signer.rs
+++ b/examples/wallets/examples/keystore_signer.rs
@@ -25,7 +25,6 @@ async fn main() -> Result<()> {
     let keystore_file_path =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR")?).join("examples/keystore/alice.json");
     let signer = Wallet::decrypt_keystore(keystore_file_path, password)?;
-    let alice = signer.address();
 
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
@@ -34,11 +33,10 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a transaction to send 100 wei to Vitalik from Alice.
-    let tx = TransactionRequest::default()
-        .with_from(alice)
-        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
-        .with_value(U256::from(100));
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    let tx = TransactionRequest::default().with_to(vitalik).with_value(U256::from(100));
 
     // Send the transaction and wait for inclusion.
     let tx_hash = provider.send_transaction(tx).await?.watch().await?;

--- a/examples/wallets/examples/ledger_signer.rs
+++ b/examples/wallets/examples/ledger_signer.rs
@@ -5,10 +5,7 @@ use alloy::{
     primitives::{address, U256},
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
-    signers::{
-        ledger::{HDPath, LedgerSigner},
-        Signer,
-    },
+    signers::ledger::{HDPath, LedgerSigner},
 };
 use eyre::Result;
 
@@ -19,7 +16,6 @@ async fn main() -> Result<()> {
 
     // Instantiate the application by acquiring a lock on the Ledger device.
     let signer = LedgerSigner::new(HDPath::LedgerLive(0), Some(1)).await?;
-    let from = signer.address();
 
     // Create a provider with the signer.
     let provider = ProviderBuilder::new()
@@ -27,11 +23,10 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a transaction to send 100 wei to Vitalik.
-    let tx = TransactionRequest::default()
-        .with_from(from)
-        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
-        .with_value(U256::from(100));
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    let tx = TransactionRequest::default().with_to(vitalik).with_value(U256::from(100));
 
     // Send the transaction and wait for inclusion with 3 confirmations.
     let tx_hash =

--- a/examples/wallets/examples/mnemonic_signer.rs
+++ b/examples/wallets/examples/mnemonic_signer.rs
@@ -9,24 +9,23 @@ async fn main() -> Result<()> {
     let index = 0u32;
     let password = "TREZOR123";
 
-    // Access mnemonic phrase with password
-    // Child key at derivation path: m/44'/60'/0'/0/{index}
+    // Access mnemonic phrase with password.
+    // Child key at derivation path: m/44'/60'/0'/0/{index}.
     let wallet = MnemonicBuilder::<English>::default()
         .phrase(phrase)
         .index(index)?
-        // Use this if your mnemonic is encrypted
+        // Use this if your mnemonic is encrypted.
         .password(password)
         .build()?;
 
     println!("Wallet: {}", wallet.address());
 
-    // Generate a random wallet (24 word phrase) at custom derivation path
+    // Generate a random wallet (24 word phrase) at custom derivation path.
     let wallet = MnemonicBuilder::<English>::default()
         .word_count(24)
         .derivation_path("m/44'/60'/0'/2/1")?
         // Optionally add this if you want the generated mnemonic to be written
-        // to a file
-        // .write_to(path)
+        // to a file `.write_to(path)`.
         .build_random()?;
 
     println!("Random wallet: {}", wallet.address());

--- a/examples/wallets/examples/private_key_signer.rs
+++ b/examples/wallets/examples/private_key_signer.rs
@@ -18,10 +18,10 @@ async fn main() -> Result<()> {
 
     // Set up signer from the first default Anvil account (Alice).
     let signer: LocalWallet = anvil.keys()[0].clone().into();
+
     // [RISK WARNING! Writing a private key in the code file is insecure behavior.]
     // The following code is for testing only. Set up signer from private key, be aware of danger.
     // let signer: LocalWallet = "<THE_PRIVATE_KEY>".parse().expect("Failed to parse private key");
-    let alice = signer.address();
 
     // Create a provider with the signer.
     let rpc_url = anvil.endpoint().parse()?;
@@ -30,9 +30,9 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a transaction to send 100 wei to Vitalik.
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    // The `from` field is automatically filled to the first signer's address (Alice).
     let tx = TransactionRequest::default()
-        .with_from(alice)
         .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
         .with_value(U256::from(100));
 

--- a/examples/wallets/examples/trezor_signer.rs
+++ b/examples/wallets/examples/trezor_signer.rs
@@ -5,10 +5,7 @@ use alloy::{
     primitives::{address, U256},
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
-    signers::{
-        trezor::{HDPath, TrezorSigner},
-        Signer,
-    },
+    signers::trezor::{HDPath, TrezorSigner},
 };
 use eyre::Result;
 
@@ -19,7 +16,6 @@ async fn main() -> Result<()> {
 
     // Instantiate the application by acquiring a lock on the Trezor device.
     let signer = TrezorSigner::new(HDPath::TrezorLive(0), Some(1)).await?;
-    let from = signer.address();
 
     // Create a provider with the signer.
     let provider = ProviderBuilder::new()
@@ -27,11 +23,10 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a transaction to send 100 wei to Vitalik.
-    let tx = TransactionRequest::default()
-        .with_from(from)
-        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
-        .with_value(U256::from(100));
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    let tx = TransactionRequest::default().with_to(vitalik).with_value(U256::from(100));
 
     // Send the transaction and wait for inclusion with 3 confirmations.
     let tx_hash =

--- a/examples/wallets/examples/yubi_signer.rs
+++ b/examples/wallets/examples/yubi_signer.rs
@@ -25,7 +25,6 @@ async fn main() -> Result<()> {
     // `from_key` method to upload a key you already have, or the `new` method
     // to generate a new keypair.
     let signer = YubiWallet::connect(connector, Credentials::default(), 0);
-    let from = signer.address();
 
     // Create a provider with the signer.
     let provider = ProviderBuilder::new()
@@ -33,11 +32,10 @@ async fn main() -> Result<()> {
         .signer(EthereumSigner::from(signer))
         .on_http(rpc_url);
 
-    // Build a transaction to send 100 wei to Vitalik.
-    let tx = TransactionRequest::default()
-        .with_from(from)
-        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
-        .with_value(U256::from(100));
+    // Build a transaction to send 100 wei from Alice to Vitalik.
+    // The `from` field is automatically filled to the first signer's address (Alice).
+    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    let tx = TransactionRequest::default().with_to(vitalik).with_value(U256::from(100));
 
     // Send the transaction and wait for inclusion with 3 confirmations.
     let tx_hash =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Only set `from` field if required (i.e. signer not set in provider or not the first signer)
- Cleans up some documentation as well

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes