### PR TITLE
feat(advanced): use AnyNetwork to get Arbitrum receipts' extra fields

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,6 +27,7 @@ jobs:
             cargo run --example 2>&1 \
             | grep -E '^ ' \
             | grep -v \
+            -e 'any_network' \
             -e 'trezor_signer' \
             -e 'ledger_signer' \
             -e 'yubi_signer' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
             cargo run --example 2>&1 \
             | grep -E '^ ' \
             | grep -v \
+            -e 'any_network' \
             -e 'trezor_signer' \
             -e 'ledger_signer' \
             -e 'yubi_signer' \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ This repository contains the following examples:
   - [x] [Yubi signer](./examples/wallets/examples/yubi_signer.rs)
   - [x] [Keystore signer](./examples/wallets/examples/keystore_signer.rs)
   - [x] [Create keystore](./examples/wallets/examples/create_keystore.rs)
+- [ ] Advanced
+  - [x] [AnyNetwork](./examples/advanced/examples/any_network.rs)
+  - [ ] Tx types / RLP serialization
+  - [ ] Showcase json and dyn ABI encoding + sol_types static encoding
 
 ## Contributing
 

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "examples-advanced"
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+alloy.workspace = true
+
+eyre.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/advanced/examples/any_network.rs
+++ b/examples/advanced/examples/any_network.rs
@@ -1,0 +1,70 @@
+//! Example of using `AnyNetwork` to get a type-safe representation of
+//! network-specific data.
+//!
+//! In this example, we extract the `gasUsedForL1` and `l1BlockNumber` fields
+//! of Arbitrum's transaction receipts.
+
+use alloy::{
+    network::{AnyNetwork, EthereumWallet},
+    primitives::{address, Address, U128, U256, U64},
+    providers::ProviderBuilder,
+    signers::local::PrivateKeySigner,
+    sol,
+};
+use eyre::Result;
+
+// The address of the contract below deployed to Arbitrum Sepolia.
+const COUNTER_CONTRACT_ADDRESS: Address = address!("d62FC4aB418580919F22E2aC3A0D93F832A95E70");
+
+sol! {
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    contract Counter {
+        uint256 public number;
+
+        function setNumber(uint256 newNumber) public {
+            number = newNumber;
+        }
+
+        function increment() public {
+            number++;
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ArbOtherFields {
+    #[serde(rename = "gasUsedForL1")]
+    gas_used_for_l1: U128,
+    #[serde(rename = "l1BlockNumber")]
+    l1_block_number: U64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // [RISK WARNING! Writing a private key in the code file is insecure behavior.]
+    // The following code is for testing only. Set up signer from private key, be aware of danger.
+    let signer: PrivateKeySigner = "<PRIVATE_KEY>".parse().expect("should parse private key");
+    let wallet = EthereumWallet::from(signer);
+
+    let rpc_url = "https://sepolia-rollup.arbitrum.io/rpc".parse()?;
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .network::<AnyNetwork>()
+        .wallet(wallet)
+        .on_http(rpc_url);
+
+    let contract = Counter::new(COUNTER_CONTRACT_ADDRESS, &provider);
+
+    let builder = contract.setNumber(U256::from(42));
+    let receipt = builder.send().await?.get_receipt().await?;
+
+    let arb_fields: ArbOtherFields = receipt.other.deserialize_into()?;
+    let l1_gas = arb_fields.gas_used_for_l1.to::<u128>();
+    let l1_block_number = arb_fields.l1_block_number.to::<u64>();
+
+    println!("Gas used for L1: {}", l1_gas);
+    println!("L1 block number: {}", l1_block_number);
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Resolves #85 

## Solution

Adds an example that uses `AnyNetwork` to extract the extra fields of an Arbitrum transaction receipt: `gasUsedForL1` and `l1BlockNumber`.

Did not use `anvil` since we want to get the receipts from an Arbitrum network. As such, added this example to the list of ignored ones in CI. Lmk if there's a way this could be improved.

## PR Checklist

- [x] Added Documentation
- [ ] Breaking changes