### PR TITLE
feat(advanced): `Provider` trait over reth-db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             -e 'ws_auth' \
             -e 'ws' \
             -e 'yubi_signer' \
-            -e 'reth_db_provider' \ 
+            -e 'reth_db_provider' \
             | xargs -n1 echo
           )"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
             -e 'ws_auth' \
             -e 'ws' \
             -e 'yubi_signer' \
+            -e 'reth_db_provider' \ 
             | xargs -n1 echo
           )"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
             -e 'ws_auth' \
             -e 'ws' \
             -e 'yubi_signer' \
-            -e 'reth_db_provider' \
             | xargs -n1 echo
           )"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
             -e 'ws_auth' \
             -e 'ws' \
             -e 'yubi_signer' \
+            -e 'reth_db_provider' \
             | xargs -n1 echo
           )"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ alloy = { version = "0.3.6", features = [
     "signer-mnemonic",
     "signer-trezor",
     "signer-yubihsm",
+    "eips",
 ] }
 
 # async
@@ -117,3 +118,6 @@ tokio = "1.40"
 eyre = "0.6"
 serde = "1.0"
 serde_json = "1.0"
+
+# [patch.crates-io]
+# alloy = { git = "https://github.com/alloy-rs/alloy", rev = "65dfbe" }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This repository contains the following examples:
   - [x] [Encoding with `dyn_abi`](./examples/advanced/examples/encoding_dyn_abi.rs)
   - [x] [Static encoding with `sol!`](./examples/advanced/examples/encoding_sol_static.rs)
   - [x] [Using `foundry-fork-db`](./examples/advanced/examples/foundry_fork_db.rs)
+  - [x] [Wrapping `Provider` trait over reth-db](./examples/advanced/examples/reth_db_provider.rs)
 
 ## Contributing
 

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,11 +19,7 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", rev = "b66e4f5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", rev = "b66e4f5" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", rev = "b66e4f5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", rev = "b66e4f5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", rev = "b66e4f5" }
+reth-alloy = { git = "https://github.com/paradigmxyz/reth", package = "reth-alloy", rev = "327d072" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,7 +19,11 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-alloy = { git = "https://github.com/paradigmxyz/reth", package = "reth-alloy", rev = "327d072" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", rev = "b66e4f5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", rev = "b66e4f5" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", rev = "b66e4f5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", rev = "b66e4f5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", rev = "b66e4f5" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,11 +19,11 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "1.0.8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "1.0.8" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "1.0.8" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "1.0.8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "1.0.8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "v1.0.8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "v1.0.8" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "v1.0.8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "v1.0.8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "v1.0.8" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,11 +19,11 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", rev = "b66e4f5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", rev = "b66e4f5" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", rev = "b66e4f5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", rev = "b66e4f5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", rev = "b66e4f5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "1.0.8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "1.0.8" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "1.0.8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "1.0.8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "1.0.8" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,8 +19,8 @@ eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "v1.0.7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "v1.0.7" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "v1.0.7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "v1.0.7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "v1.0.7" }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,3 +19,8 @@ eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum" }

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,11 +19,11 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "v1.0.7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "v1.0.7" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "v1.0.7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "v1.0.7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "v1.0.7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", rev = "b66e4f5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", rev = "b66e4f5" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", rev = "b66e4f5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", rev = "b66e4f5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", rev = "b66e4f5" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/advanced/examples/reth_db_layer.rs
+++ b/examples/advanced/examples/reth_db_layer.rs
@@ -1,3 +1,4 @@
+#![allow(unreachable_pub)]
 use std::path::PathBuf;
 
 /// We use the tower-like layering functionality that has been baked into the alloy-provider to

--- a/examples/advanced/examples/reth_db_layer.rs
+++ b/examples/advanced/examples/reth_db_layer.rs
@@ -5,12 +5,12 @@ use std::path::PathBuf;
 
 /// We use the tower-like layering functionality that has been baked into the alloy-provider to
 /// intercept the requests and redirect to the `RethDbProvider`.
-pub(crate) struct RethDBLayer {
+pub(crate) struct RethDbLayer {
     db_path: PathBuf,
 }
 
 /// Initialize the `RethDBLayer` with the path to the reth datadir.
-impl RethDBLayer {
+impl RethDbLayer {
     pub(crate) const fn new(db_path: PathBuf) -> Self {
         Self { db_path }
     }

--- a/examples/advanced/examples/reth_db_layer.rs
+++ b/examples/advanced/examples/reth_db_layer.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+/// We use the tower-like layering functionality that has been baked into the alloy-provider to
+/// intercept the requests and redirect to the `RethDbProvider`.
+pub struct RethDBLayer {
+    db_path: PathBuf,
+}
+
+/// Initialize the `RethDBLayer` with the path to the reth datadir.
+impl RethDBLayer {
+    pub const fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+
+    pub const fn db_path(&self) -> &PathBuf {
+        &self.db_path
+    }
+}

--- a/examples/advanced/examples/reth_db_layer.rs
+++ b/examples/advanced/examples/reth_db_layer.rs
@@ -1,19 +1,23 @@
-#![allow(unreachable_pub)]
+//! `RethDbLayer` implementation to be used with `RethDbProvider` to wrap the Provider trait over
+//! reth-db.
+#![allow(dead_code)]
 use std::path::PathBuf;
 
 /// We use the tower-like layering functionality that has been baked into the alloy-provider to
 /// intercept the requests and redirect to the `RethDbProvider`.
-pub struct RethDBLayer {
+pub(crate) struct RethDBLayer {
     db_path: PathBuf,
 }
 
 /// Initialize the `RethDBLayer` with the path to the reth datadir.
 impl RethDBLayer {
-    pub const fn new(db_path: PathBuf) -> Self {
+    pub(crate) const fn new(db_path: PathBuf) -> Self {
         Self { db_path }
     }
 
-    pub const fn db_path(&self) -> &PathBuf {
+    pub(crate) const fn db_path(&self) -> &PathBuf {
         &self.db_path
     }
 }
+
+const fn main() {}

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -23,7 +23,7 @@ use reth_alloy::RethDbLayer;
 async fn main() -> Result<()> {
     run_with_tempdir("provider-call-reth-db", |data_dir| async move {
         // Initializing reth with a tmp data directory.
-        // We use a tmp directory for the purposes of this example.
+        // We use a tmp directory for the purpose of this example.
         // This would actually use an existing reth datadir specified by `--datadir` when starting
         // your reth node.
         let reth = Reth::new()

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -125,7 +125,7 @@ impl<P, T> RethDBProvider<P, T> {
         }
     }
 
-    fn factory(&self) -> &WrapProviderFactory {
+    const fn factory(&self) -> &WrapProviderFactory {
         &self.provider_factory
     }
 
@@ -177,7 +177,7 @@ struct WrapProviderFactory {
 }
 
 impl WrapProviderFactory {
-    fn new(
+    const fn new(
         inner: Arc<ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>,
     ) -> Self {
         Self { inner }

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -23,7 +23,7 @@ use reth_alloy::RethDbLayer;
 async fn main() -> Result<()> {
     run_with_tempdir("provider-call-reth-db", |data_dir| async move {
         // Initializing reth with a tmp data directory.
-        // We use a tmp directory for the purpose of this example.
+        // We use a tmp directory for the purposes of this example.
         // This would actually use an existing reth datadir specified by `--datadir` when starting
         // your reth node.
         let reth = Reth::new()

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -93,18 +93,8 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// We use the tower-like layering functionality that has been baked into the alloy-provider to
-/// intercept the requests and redirect to the `RethDbProvider`.
-struct RethDBLayer {
-    db_path: PathBuf,
-}
-
-/// Initialize the `RethDBLayer` with the path to the reth datadir.
-impl RethDBLayer {
-    const fn new(db_path: PathBuf) -> Self {
-        Self { db_path }
-    }
-}
+mod reth_db_layer;
+use reth_db_layer::RethDBLayer;
 
 /// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
 impl<P, T> ProviderLayer<P, T> for RethDBLayer
@@ -115,7 +105,7 @@ where
     type Provider = RethDbProvider<P, T>;
 
     fn layer(&self, inner: P) -> Self::Provider {
-        RethDbProvider::new(inner, self.db_path.clone())
+        RethDbProvider::new(inner, self.db_path().clone())
     }
 }
 

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -33,12 +33,15 @@ use reth_provider::{
     ProviderFactory, StateProvider, TryIntoHistoricalStateProvider,
 };
 mod reth_db_layer;
-use reth_db_layer::RethDBLayer;
+use reth_db_layer::RethDbLayer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     run_with_tempdir("provider-call-reth-db", |data_dir| async move {
-        // Initialize reth node with a specific data directory
+        // Initializing reth with a tmp data directory.
+        // We use a tmp directory for the purposes of this example.
+        // This would actually use an existing reth datadir specified by `--datadir` when starting
+        // your reth node.
         let reth = Reth::new()
             .dev()
             .disable_discovery()
@@ -53,7 +56,7 @@ async fn main() -> Result<()> {
         // Any RPC method that is not implemented in the RethDbProvider gracefully falls back to the
         // RPC provider specified in the `on_http` method.
         let provider =
-            ProviderBuilder::new().layer(RethDBLayer::new(db_path)).on_http(reth.endpoint_url());
+            ProviderBuilder::new().layer(RethDbLayer::new(db_path)).on_http(reth.endpoint_url());
 
         // Initialize the RPC provider to compare the time taken to fetch the results.
         let rpc_provider = ProviderBuilder::new().on_http(reth.endpoint_url());
@@ -92,7 +95,7 @@ async fn main() -> Result<()> {
 }
 
 /// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
-impl<P, T> ProviderLayer<P, T> for RethDBLayer
+impl<P, T> ProviderLayer<P, T> for RethDbLayer
 where
     P: Provider<T>,
     T: Transport + Clone,

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -32,6 +32,8 @@ use reth_provider::{
     providers::StaticFileProvider, BlockNumReader, DatabaseProviderFactory, ProviderError,
     ProviderFactory, StateProvider, TryIntoHistoricalStateProvider,
 };
+mod reth_db_layer;
+use reth_db_layer::RethDBLayer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -88,9 +90,6 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
-
-mod reth_db_layer;
-use reth_db_layer::RethDBLayer;
 
 /// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
 impl<P, T> ProviderLayer<P, T> for RethDBLayer

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -10,14 +10,30 @@
 //! their own implementation of the `Provider` trait and fetch results from any source.
 //!
 //! Learn more about `ProviderCall` [here](https://github.com/alloy-rs/alloy/pull/788).
+use std::{marker::PhantomData, path::PathBuf, sync::Arc};
+
 use alloy::{
-    eips::BlockId,
+    eips::{BlockId, BlockNumberOrTag},
     node_bindings::{utils::run_with_tempdir, Reth},
-    primitives::address,
-    providers::{Provider, ProviderBuilder},
+    primitives::{address, Address, U64},
+    providers::{
+        Provider, ProviderBuilder, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock,
+    },
+    rpc::client::NoParams,
+    transports::{Transport, TransportErrorKind},
 };
 use eyre::Result;
-use reth_alloy::RethDbLayer;
+
+use reth_chainspec::ChainSpecBuilder;
+use reth_db::{open_db_read_only, DatabaseEnv};
+use reth_node_ethereum::EthereumNode;
+use reth_node_types::NodeTypesWithDBAdapter;
+use reth_provider::{
+    providers::StaticFileProvider, BlockNumReader, DatabaseProviderFactory, ProviderError,
+    ProviderFactory, StateProvider, TryIntoHistoricalStateProvider,
+};
+mod reth_db_layer;
+use reth_db_layer::RethDbLayer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -76,4 +92,135 @@ async fn main() -> Result<()> {
     .await;
 
     Ok(())
+}
+
+/// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
+impl<P, T> ProviderLayer<P, T> for RethDbLayer
+where
+    P: Provider<T>,
+    T: Transport + Clone,
+{
+    type Provider = RethDbProvider<P, T>;
+
+    fn layer(&self, inner: P) -> Self::Provider {
+        RethDbProvider::new(inner, self.db_path().clone())
+    }
+}
+
+/// A provider that overrides the vanilla `Provider` trait to get results from the reth-db.
+///
+/// It holds the `reth_provider::ProviderFactory` that enables read-only access to the database
+/// tables and static files.
+#[derive(Clone, Debug)]
+pub struct RethDbProvider<P, T> {
+    inner: P,
+    db_path: PathBuf,
+    provider_factory: DbAccessor,
+    _pd: PhantomData<T>,
+}
+
+impl<P, T> RethDbProvider<P, T> {
+    /// Create a new `RethDbProvider` instance.
+    pub fn new(inner: P, db_path: PathBuf) -> Self {
+        let db = open_db_read_only(&db_path, Default::default()).unwrap();
+        let chain_spec = ChainSpecBuilder::mainnet().build();
+        let static_file_provider =
+            StaticFileProvider::read_only(db_path.join("static_files"), false).unwrap();
+
+        let provider_factory =
+            ProviderFactory::new(db.into(), chain_spec.into(), static_file_provider);
+
+        let db_accessor: DbAccessor<
+            ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>,
+        > = DbAccessor::new(provider_factory);
+        Self { inner, db_path, provider_factory: db_accessor, _pd: PhantomData }
+    }
+
+    const fn factory(&self) -> &DbAccessor {
+        &self.provider_factory
+    }
+
+    /// Get the DB Path
+    pub fn db_path(&self) -> PathBuf {
+        self.db_path.clone()
+    }
+}
+
+/// Implement the `Provider` trait for the `RethDbProvider` struct.
+///
+/// This is where we override specific RPC methods to fetch from the reth-db.
+impl<P, T> Provider<T> for RethDbProvider<P, T>
+where
+    P: Provider<T>,
+    T: Transport + Clone,
+{
+    fn root(&self) -> &RootProvider<T> {
+        self.inner.root()
+    }
+
+    /// Override the `get_block_number` method to fetch the latest block number from the reth-db.
+    fn get_block_number(&self) -> ProviderCall<T, NoParams, U64, u64> {
+        let provider = self.factory().provider().map_err(TransportErrorKind::custom).unwrap();
+
+        let best = provider.best_block_number().map_err(TransportErrorKind::custom);
+
+        ProviderCall::ready(best)
+    }
+
+    /// Override the `get_transaction_count` method to fetch the transaction count of an address.
+    ///
+    /// `RpcWithBlock` uses `ProviderCall` under the hood.
+    fn get_transaction_count(&self, address: Address) -> RpcWithBlock<T, Address, U64, u64> {
+        let this = self.factory().clone();
+        RpcWithBlock::new_provider(move |block_id| {
+            let provider = this.provider_at(block_id).map_err(TransportErrorKind::custom).unwrap();
+
+            let maybe_acc =
+                provider.basic_account(address).map_err(TransportErrorKind::custom).unwrap();
+
+            let nonce = maybe_acc.map(|acc| acc.nonce).unwrap_or_default();
+
+            ProviderCall::ready(Ok(nonce))
+        })
+    }
+}
+
+/// A helper type to get the appropriate DB provider.
+#[derive(Debug, Clone)]
+struct DbAccessor<DB = ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>
+where
+    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
+{
+    inner: DB,
+}
+
+impl<DB> DbAccessor<DB>
+where
+    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
+{
+    const fn new(inner: DB) -> Self {
+        Self { inner }
+    }
+
+    fn provider(&self) -> Result<DB::Provider, ProviderError> {
+        self.inner.database_provider_ro()
+    }
+
+    fn provider_at(&self, block_id: BlockId) -> Result<Box<dyn StateProvider>, ProviderError> {
+        let provider = self.inner.database_provider_ro()?;
+
+        let block_number = match block_id {
+            BlockId::Hash(hash) => {
+                if let Some(num) = provider.block_number(hash.into())? {
+                    num
+                } else {
+                    return Err(ProviderError::BlockHashNotFound(hash.into()));
+                }
+            }
+            BlockId::Number(BlockNumberOrTag::Number(num)) => num,
+            _ => provider.best_block_number()?,
+        };
+
+        provider.try_into_history_at_block(block_number)
+    }
 }

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -10,30 +10,14 @@
 //! their own implementation of the `Provider` trait and fetch results from any source.
 //!
 //! Learn more about `ProviderCall` [here](https://github.com/alloy-rs/alloy/pull/788).
-use std::{marker::PhantomData, path::PathBuf, sync::Arc};
-
 use alloy::{
-    eips::{BlockId, BlockNumberOrTag},
+    eips::BlockId,
     node_bindings::{utils::run_with_tempdir, Reth},
-    primitives::{address, Address, U64},
-    providers::{
-        Provider, ProviderBuilder, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock,
-    },
-    rpc::client::NoParams,
-    transports::{Transport, TransportErrorKind},
+    primitives::address,
+    providers::{Provider, ProviderBuilder},
 };
 use eyre::Result;
-
-use reth_chainspec::ChainSpecBuilder;
-use reth_db::{open_db_read_only, DatabaseEnv};
-use reth_node_ethereum::EthereumNode;
-use reth_node_types::NodeTypesWithDBAdapter;
-use reth_provider::{
-    providers::StaticFileProvider, BlockNumReader, DatabaseProviderFactory, ProviderError,
-    ProviderFactory, StateProvider, TryIntoHistoricalStateProvider,
-};
-mod reth_db_layer;
-use reth_db_layer::RethDbLayer;
+use reth_alloy::RethDbLayer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -92,135 +76,4 @@ async fn main() -> Result<()> {
     .await;
 
     Ok(())
-}
-
-/// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
-impl<P, T> ProviderLayer<P, T> for RethDbLayer
-where
-    P: Provider<T>,
-    T: Transport + Clone,
-{
-    type Provider = RethDbProvider<P, T>;
-
-    fn layer(&self, inner: P) -> Self::Provider {
-        RethDbProvider::new(inner, self.db_path().clone())
-    }
-}
-
-/// A provider that overrides the vanilla `Provider` trait to get results from the reth-db.
-///
-/// It holds the `reth_provider::ProviderFactory` that enables read-only access to the database
-/// tables and static files.
-#[derive(Clone, Debug)]
-pub struct RethDbProvider<P, T> {
-    inner: P,
-    db_path: PathBuf,
-    provider_factory: DbAccessor,
-    _pd: PhantomData<T>,
-}
-
-impl<P, T> RethDbProvider<P, T> {
-    /// Create a new `RethDbProvider` instance.
-    pub fn new(inner: P, db_path: PathBuf) -> Self {
-        let db = open_db_read_only(&db_path, Default::default()).unwrap();
-        let chain_spec = ChainSpecBuilder::mainnet().build();
-        let static_file_provider =
-            StaticFileProvider::read_only(db_path.join("static_files"), false).unwrap();
-
-        let provider_factory =
-            ProviderFactory::new(db.into(), chain_spec.into(), static_file_provider);
-
-        let db_accessor: DbAccessor<
-            ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>,
-        > = DbAccessor::new(provider_factory);
-        Self { inner, db_path, provider_factory: db_accessor, _pd: PhantomData }
-    }
-
-    const fn factory(&self) -> &DbAccessor {
-        &self.provider_factory
-    }
-
-    /// Get the DB Path
-    pub fn db_path(&self) -> PathBuf {
-        self.db_path.clone()
-    }
-}
-
-/// Implement the `Provider` trait for the `RethDbProvider` struct.
-///
-/// This is where we override specific RPC methods to fetch from the reth-db.
-impl<P, T> Provider<T> for RethDbProvider<P, T>
-where
-    P: Provider<T>,
-    T: Transport + Clone,
-{
-    fn root(&self) -> &RootProvider<T> {
-        self.inner.root()
-    }
-
-    /// Override the `get_block_number` method to fetch the latest block number from the reth-db.
-    fn get_block_number(&self) -> ProviderCall<T, NoParams, U64, u64> {
-        let provider = self.factory().provider().map_err(TransportErrorKind::custom).unwrap();
-
-        let best = provider.best_block_number().map_err(TransportErrorKind::custom);
-
-        ProviderCall::ready(best)
-    }
-
-    /// Override the `get_transaction_count` method to fetch the transaction count of an address.
-    ///
-    /// `RpcWithBlock` uses `ProviderCall` under the hood.
-    fn get_transaction_count(&self, address: Address) -> RpcWithBlock<T, Address, U64, u64> {
-        let this = self.factory().clone();
-        RpcWithBlock::new_provider(move |block_id| {
-            let provider = this.provider_at(block_id).map_err(TransportErrorKind::custom).unwrap();
-
-            let maybe_acc =
-                provider.basic_account(address).map_err(TransportErrorKind::custom).unwrap();
-
-            let nonce = maybe_acc.map(|acc| acc.nonce).unwrap_or_default();
-
-            ProviderCall::ready(Ok(nonce))
-        })
-    }
-}
-
-/// A helper type to get the appropriate DB provider.
-#[derive(Debug, Clone)]
-struct DbAccessor<DB = ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>
-where
-    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
-{
-    inner: DB,
-}
-
-impl<DB> DbAccessor<DB>
-where
-    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
-{
-    const fn new(inner: DB) -> Self {
-        Self { inner }
-    }
-
-    fn provider(&self) -> Result<DB::Provider, ProviderError> {
-        self.inner.database_provider_ro()
-    }
-
-    fn provider_at(&self, block_id: BlockId) -> Result<Box<dyn StateProvider>, ProviderError> {
-        let provider = self.inner.database_provider_ro()?;
-
-        let block_number = match block_id {
-            BlockId::Hash(hash) => {
-                if let Some(num) = provider.block_number(hash.into())? {
-                    num
-                } else {
-                    return Err(ProviderError::BlockHashNotFound(hash.into()));
-                }
-            }
-            BlockId::Number(BlockNumberOrTag::Number(num)) => num,
-            _ => provider.best_block_number()?,
-        };
-
-        provider.try_into_history_at_block(block_number)
-    }
 }

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -1,4 +1,15 @@
-//! Demonstrates how to leverage `ProviderCall` to wrap the `Provider` trait over reth-db.
+//! `ProviderCall` enables the alloy-provider to fetch results of a rpc request from arbitrary
+//! sources. These arbitray sources could be a RPC call over the network, a local database, or even
+//! a synchronous function call.
+//!
+//! `ProviderCall` is the final future in the flow of an rpc request and is used by the
+//! `RpcWithBlock` and `EthCall` types under the hood to give flexibility to the user to use
+//! their own implementation of the `Provider` trait and fetch results from any source.
+//!
+//! In this minimal example, we demonstrate how we wrap the `Provider` trait over reth-db and
+//! leverage `ProviderCall`.
+//!
+//! Learn more about `ProviderCall` [here](https://github.com/alloy-rs/alloy/pull/788).
 use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
 use alloy::{
@@ -29,6 +40,7 @@ use reth_provider::{
 #[tokio::main]
 async fn main() -> Result<()> {
     run_with_tempdir("provider-call-reth-db", |data_dir| async move {
+        // Initialize reth node with a specific data directory
         let reth = Reth::new()
             .dev()
             .disable_discovery()
@@ -38,53 +50,63 @@ async fn main() -> Result<()> {
 
         let db_path = data_dir.join("db");
 
+        // Initialize the provider with the reth-db layer. The reth-db layer intercepts the rpc
+        // requests and returns the results from the reth-db database.
+        // Any RPC method that is not implemented in the RethDBProvider gracefully falls back to the
+        // RPC provider specified in the `on_http` method.
         let provider =
             ProviderBuilder::new().layer(RethDBLayer::new(db_path)).on_http(reth.endpoint_url());
 
+        // Initialize the RPC provider to compare the time taken to fetch the results.
         let rpc_provider = ProviderBuilder::new().on_http(reth.endpoint_url());
 
-        let start_t = std::time::Instant::now();
-        let latest_block = provider.get_block_number().await.unwrap();
-        println!("Latest block from DB={latest_block} | Time Taken: {:?}", start_t.elapsed());
+        println!("--------get_block_number---------");
 
         let start_t = std::time::Instant::now();
-        let latest_block = rpc_provider.get_block_number().await.unwrap();
-        println!("Latest block from RPC={latest_block} | Time Taken: {:?}", start_t.elapsed());
+        let latest_block_db = provider.get_block_number().await.unwrap();
+        println!("via reth-db: {:?}", start_t.elapsed());
+
+        let start_t = std::time::Instant::now();
+        let latest_block_rpc = rpc_provider.get_block_number().await.unwrap();
+        println!("via rpc:     {:?}\n", start_t.elapsed());
+
+        assert_eq!(latest_block_db, latest_block_rpc);
+
+        println!("------get_transaction_count------");
 
         let alice = address!("14dC79964da2C08b23698B3D3cc7Ca32193d9955");
 
         let start_t = std::time::Instant::now();
-        let nonce = provider.get_transaction_count(alice).await.unwrap();
-        println!("Nonce from DB={nonce} | Time Taken: {:?}", start_t.elapsed());
+        let nonce_db =
+            provider.get_transaction_count(alice).block_id(BlockId::latest()).await.unwrap();
+        println!("via reth-db: {:?}", start_t.elapsed());
 
         let start_t = std::time::Instant::now();
-        let nonce = rpc_provider.get_transaction_count(alice).await.unwrap();
-        println!("Nonce from RPC={nonce} | Time Taken: {:?}", start_t.elapsed());
+        let nonce_rpc =
+            rpc_provider.get_transaction_count(alice).block_id(BlockId::latest()).await.unwrap();
+        println!("via rpc:     {:?}\n", start_t.elapsed());
 
-        let nonce_at_block = provider
-            .get_transaction_count(alice)
-            .block_id(BlockId::Number(BlockNumberOrTag::Number(1)))
-            .await
-            .unwrap();
-        println!("Nonce from DB at block 1={nonce_at_block}");
+        assert_eq!(nonce_db, nonce_rpc);
     })
     .await;
 
     Ok(())
 }
 
-/// A `ProviderLayer` that wraps the `Provider` trait over reth-db.
+/// We use the tower-like layering functionality that has been baked into the alloy-provider to
+/// intercept the requests and redirect to the `RethDBProvider`.
 struct RethDBLayer {
     db_path: PathBuf,
 }
 
-/// Implement the `ProviderLayer` trait for `RethDBLayer`.
+/// Initialize the `RethDBLayer` with the path to the reth datadir.
 impl RethDBLayer {
     const fn new(db_path: PathBuf) -> Self {
         Self { db_path }
     }
 }
 
+/// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
 impl<P, T> ProviderLayer<P, T> for RethDBLayer
 where
     P: Provider<T>,
@@ -97,7 +119,10 @@ where
     }
 }
 
-/// A provider that wraps the `Provider` trait over reth-db.
+/// A provider that overrides the vanilla `Provider` trait to get results from the reth-db.
+///
+/// It holds the `reth_provider::ProviderFactory` that enables read-only access to the database
+/// tables and static files.
 #[derive(Clone, Debug)]
 pub struct RethDBProvider<P, T> {
     inner: P,
@@ -135,6 +160,9 @@ impl<P, T> RethDBProvider<P, T> {
     }
 }
 
+/// Implement the `Provider` trait for the `RethDBProvider` struct.
+///
+/// This is where we override specific RPC methods to fetch from the reth-db.
 impl<P, T> Provider<T> for RethDBProvider<P, T>
 where
     P: Provider<T>,
@@ -144,6 +172,7 @@ where
         self.inner.root()
     }
 
+    /// Override the `get_block_number` method to fetch the latest block number from the reth-db.
     fn get_block_number(&self) -> ProviderCall<T, NoParams, U64, u64> {
         let provider = self.factory().provider().map_err(TransportErrorKind::custom).unwrap();
 
@@ -154,6 +183,9 @@ where
         ProviderCall::<T, NoParams, U64, u64>::ready(best)
     }
 
+    /// Override the `get_transaction_count` method to fetch the transaction count of an address.
+    ///
+    /// `RpcWithBlock` uses `ProviderCall` under the hood.
     fn get_transaction_count(&self, address: Address) -> RpcWithBlock<T, Address, U64, u64> {
         let this = self.factory().clone();
         RpcWithBlock::new_provider(move |block_id| {
@@ -171,6 +203,7 @@ where
     }
 }
 
+/// A helper type to get the appropriate DB provider from `reth_provider::ProviderFactory`.
 #[derive(Clone, Debug)]
 struct WrapProviderFactory {
     inner: Arc<ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>,
@@ -183,11 +216,12 @@ impl WrapProviderFactory {
         Self { inner }
     }
 
-    /// Get the DB provider.
+    /// Get a read-only `DatabaseProvider`
     fn provider(&self) -> Result<DatabaseProvider<Tx<RO>, ChainSpec>, ProviderError> {
         self.inner.provider()
     }
 
+    /// Get a read-only `DatabaseProvider` at a specific block
     fn provider_at(
         &self,
         block_id: BlockId,

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -168,7 +168,7 @@ where
 
         let best = provider.best_block_number().map_err(TransportErrorKind::custom);
 
-        ProviderCall::<T, NoParams, U64, u64>::ready(best)
+        ProviderCall::ready(best)
     }
 
     /// Override the `get_transaction_count` method to fetch the transaction count of an address.
@@ -184,7 +184,7 @@ where
 
             let nonce = maybe_acc.map(|acc| acc.nonce).unwrap_or_default();
 
-            ProviderCall::<T, ParamsWithBlock<Address>, U64, u64>::ready(Ok(nonce))
+            ProviderCall::ready(Ok(nonce))
         })
     }
 }

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -197,10 +197,7 @@ impl WrapProviderFactory {
             BlockId::Number(BlockNumberOrTag::Number(num)) => {
                 self.inner.history_by_block_number(num)
             }
-            BlockId::Number(tag) => match tag {
-                BlockNumberOrTag::Latest => self.inner.latest(),
-                _ => self.inner.latest(),
-            },
+            _ => self.inner.latest(),
         }
     }
 }

--- a/examples/advanced/examples/reth_db_provider.rs
+++ b/examples/advanced/examples/reth_db_provider.rs
@@ -1,0 +1,121 @@
+//! Demonstrates how to leverage `ProviderCall` to wrap the `Provider` trait over reth-db.
+use std::{marker::PhantomData, path::PathBuf, str::FromStr, sync::Arc};
+
+use alloy::{
+    primitives::U64,
+    providers::{Provider, ProviderBuilder, ProviderCall, ProviderLayer, RootProvider},
+    rpc::client::NoParams,
+    transports::{Transport, TransportErrorKind},
+};
+use eyre::Result;
+
+use reth_chainspec::{ChainSpec, ChainSpecBuilder};
+use reth_db::{
+    mdbx::{tx::Tx, RO},
+    DatabaseEnv,
+};
+use reth_node_ethereum::EthereumNode;
+use reth_node_types::NodeTypesWithDBAdapter;
+use reth_provider::{
+    providers::StaticFileProvider, BlockNumReader, DatabaseProvider, ProviderError, ProviderFactory,
+};
+
+/// A `ProviderLayer` that wraps the `Provider` trait over reth-db.
+struct RethDBLayer {
+    db_path: PathBuf,
+}
+
+/// Implement the `ProviderLayer` trait for `RethDBLayer`.
+impl RethDBLayer {
+    const fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+}
+
+impl<P, T> ProviderLayer<P, T> for RethDBLayer
+where
+    P: Provider<T>,
+    T: Transport + Clone,
+{
+    type Provider = RethDBProvider<P, T>;
+
+    fn layer(&self, inner: P) -> Self::Provider {
+        RethDBProvider::new(inner, self.db_path.clone())
+    }
+}
+
+/// A provider that wraps the `Provider` trait over reth-db.
+#[derive(Clone, Debug)]
+pub struct RethDBProvider<P, T> {
+    inner: P,
+    db_path: PathBuf,
+    provider_factory: ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>,
+    _pd: PhantomData<T>,
+}
+
+impl<P, T> RethDBProvider<P, T> {
+    /// Create a new `RethDBProvider` instance.
+    pub fn new(inner: P, db_path: PathBuf) -> Self {
+        let chain_spec = ChainSpecBuilder::mainnet().build();
+        let provider_factory =
+            ProviderFactory::<NodeTypesWithDBAdapter<EthereumNode, _>>::new_with_database_path(
+                db_path.clone(),
+                chain_spec.into(),
+                Default::default(),
+                StaticFileProvider::read_only(db_path.join("static_files"), false).unwrap(),
+            )
+            .unwrap();
+
+        Self { inner, db_path, provider_factory, _pd: PhantomData }
+    }
+
+    /// Get the DB provider.
+    fn provider(&self) -> Result<DatabaseProvider<Tx<RO>, ChainSpec>, ProviderError> {
+        self.provider_factory.provider()
+    }
+
+    /// Get the DB Path
+    pub fn db_path(&self) -> PathBuf {
+        self.db_path.clone()
+    }
+}
+
+impl<P, T> Provider<T> for RethDBProvider<P, T>
+where
+    P: Provider<T>,
+    T: Transport + Clone,
+{
+    fn root(&self) -> &RootProvider<T> {
+        self.inner.root()
+    }
+
+    fn get_block_number(&self) -> ProviderCall<T, NoParams, U64, u64> {
+        println!("Getting best block number from db");
+
+        let provider = self.provider().unwrap();
+
+        let best = provider.best_block_number().map_err(TransportErrorKind::custom);
+
+        ProviderCall::<T, NoParams, U64, u64>::ready(best)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let db_path = PathBuf::from_str("DB_PATH")?;
+    let provider = ProviderBuilder::new()
+        .layer(RethDBLayer::new(db_path))
+        .on_http("http://127.0.0.1:8545".parse().unwrap());
+
+    let rpc_provider = ProviderBuilder::new().on_http("http://127.0.0.1:8545".parse().unwrap());
+
+    let start_t = std::time::Instant::now();
+    let latest_block = provider.get_block_number().await?;
+    println!("Latest block from DB {latest_block} | Time Taken: {:?}", start_t.elapsed());
+
+    let start_t = std::time::Instant::now();
+    let latest_block = rpc_provider.get_block_number().await?;
+    println!("Latest block from RPC {latest_block} | Time Taken: {:?}", start_t.elapsed());
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

In the latest release of alloy-0.3.6, `ProviderCall` was introduced as a return type in the `Provider` trait.

`ProviderCall` enables to fetch the result of an RPC call from any data source such as the node's db, cache etc. 

More on this can be found here https://github.com/alloy-rs/alloy/pull/788

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Example showing how to wrap the `Provider` trait over reth-db and use `ProviderCall` to fetch responses from the db directly. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Documentation
- [ ] Breaking changes