### PR TITLE
chore: bump to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ non_send_fields_in_send_ty = "allow"
 redundant_pub_crate = "allow"
 significant_drop_in_scrutinee = "allow"
 significant_drop_tightening = "allow"
+needless_return = "allow"
 
 [workspace.dependencies]
 alloy = { version = "0.4.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ significant_drop_in_scrutinee = "allow"
 significant_drop_tightening = "allow"
 
 [workspace.dependencies]
-alloy = { version = "0.3.6", features = [
+alloy = { version = "0.4.0", features = [
     "full",
     "node-bindings",
     "rpc-types-debug",


### PR DESCRIPTION
Bumps to Alloy `0.4.0`, no breaking changes

Temporarily disable new `clippy::needless_return` rule see: https://github.com/tokio-rs/tokio/issues/6869#issuecomment-2375942611