### PR TITLE
chore: bump to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ alloy = { version = "0.5.2", features = [
 ] }
 
 foundry-fork-db = "0.5"
-revm-primitives = "10.0"
-revm = "14.0"
+revm-primitives = "12.0"
+revm = "16.0"
 
 # async
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ significant_drop_tightening = "allow"
 needless_return = "allow"
 
 [workspace.dependencies]
-alloy = { version = "0.4.1", features = [
+alloy = { version = "0.5.2", features = [
     "full",
     "node-bindings",
     "rpc-types-debug",
@@ -111,7 +111,7 @@ alloy = { version = "0.4.1", features = [
     "eips",
 ] }
 
-foundry-fork-db = "0.4"
+foundry-fork-db = "0.5"
 revm-primitives = "10.0"
 revm = "14.0"
 

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -19,11 +19,11 @@ revm-primitives.workspace = true
 revm.workspace = true
 
 # reth
-reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "v1.0.8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "v1.0.8" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "v1.0.8" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "v1.0.8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "v1.0.8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", package = "reth-db", tag = "v1.1.0" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", package = "reth-provider", tag = "v1.1.0" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-types", tag = "v1.1.0" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", package = "reth-chainspec", tag = "v1.1.0" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", package = "reth-node-ethereum", tag = "v1.1.0" }
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/layers/Cargo.toml
+++ b/examples/layers/Cargo.toml
@@ -17,4 +17,4 @@ alloy.workspace = true
 
 eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tower = { version = "0.4", features = ["retry"] }
+tower = { version = "0.5", features = ["retry"] }

--- a/examples/providers/examples/ws_with_auth.rs
+++ b/examples/providers/examples/ws_with_auth.rs
@@ -15,8 +15,8 @@ async fn main() -> Result<()> {
 
     // Create the WS connection object with authentication.
     let rpc_url = "wss://your-ws-endpoint.com/";
-    let ws_basic = WsConnect::with_auth(rpc_url, Some(auth));
-    let ws_bearer = WsConnect::with_auth(rpc_url, Some(auth_bearer));
+    let ws_basic = WsConnect::new(rpc_url).with_auth(auth);
+    let ws_bearer = WsConnect::new(rpc_url).with_auth(auth_bearer);
 
     // Create the provider.
     let provider_basic = ProviderBuilder::new().on_ws(ws_basic).await?;

--- a/examples/transactions/examples/send_eip7702_transaction.rs
+++ b/examples/transactions/examples/send_eip7702_transaction.rs
@@ -4,7 +4,6 @@ use alloy::{
     eips::eip7702::Authorization,
     network::{EthereumWallet, TransactionBuilder, TransactionBuilder7702},
     node_bindings::Anvil,
-    primitives::U256,
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
     signers::{local::PrivateKeySigner, SignerSync},
@@ -54,7 +53,7 @@ async fn main() -> Result<()> {
 
     // Create an authorization object for Alice to sign.
     let authorization = Authorization {
-        chain_id: U256::from(anvil.chain_id()),
+        chain_id: anvil.chain_id(),
         // Reference to the contract that will be set as code for the authority.
         address: *contract.address(),
         nonce: provider.get_transaction_count(alice.address()).await?,

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -16,9 +16,9 @@ workspace = true
 alloy.workspace = true
 
 aws-config = { version = "1.5", default-features = false }
-aws-sdk-kms = { version = "1.46", default-features = false }
+aws-sdk-kms = { version = "1.47", default-features = false }
 eyre.workspace = true
 rand = "0.8"
 serde = { workspace = true, features = ["derive"] }
-tempfile = "3.10"
+tempfile = "3.13"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Bumps Alloy to `0.5.2`

## Solution

Updates Alloy to `0.5.2` as well as all other dependencies (incl. `revm` to fix a perceived breaking in `foundry-fork-db`).

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes