### PR TITLE
chore: bump deps, foundry-fork-db to `0.9`, alloy to `0.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ significant_drop_tightening = "allow"
 needless_return = "allow"
 
 [workspace.dependencies]
-alloy = { version = "0.7", features = [
+alloy = { version = "0.8", features = [
     "eips",
     "full",
     "hyper",
@@ -113,14 +113,14 @@ alloy = { version = "0.7", features = [
     "signer-yubihsm",
 ] }
 
-foundry-fork-db = "0.8"
+foundry-fork-db = "0.9"
 
 revm-primitives = "14.0"
 revm = "18.0"
 
 # async
 futures-util = "0.3"
-tokio = "1.41"
+tokio = "1.42"
 
 # misc
 eyre = "0.6"

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 alloy.workspace = true
 
 aws-config = { version = "1.5", default-features = false }
-aws-sdk-kms = { version = "1.50", default-features = false }
+aws-sdk-kms = { version = "1.51", default-features = false }
 eyre.workspace = true
 gcloud-sdk = {version = "0.25", features = [
     "google-cloud-kms-v1",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Bumps to Alloy `0.8`, Foundry's fork DB to `0.9`

Note: `gcloud-sdk` has a new `0.26` version available but this is not yet updated in Alloy

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes