### PR TITLE
chore(`ci`): speed up CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run examples
         run: |
           # Run examples with the current version of Alloy
-          ./scripts/run.sh
+          ./scripts/test.sh
 
           # Fetch the latest commit hash of the `main` branch from the Alloy repository
           export latest_alloy_commit=$(git ls-remote https://github.com/alloy-rs/alloy.git \
@@ -38,4 +38,4 @@ jobs:
           cargo update
 
           # Run the examples with the latest version of Alloy
-          ./scripts/run.sh
+          ./scripts/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           cache-on-failure: true
       - name: Run examples
-        run: ./scripts/run.sh
+        run: ./scripts/test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ participate in the discussion around bugs and participate in reviewing PRs.
 
 ### Contributions Related to Spelling and Grammar
 
-At this time, we will not be accepting contributions that only fix spelling 
+At this time, we will not be accepting contributions that only fix spelling
 or grammatical errors in documentation, code or elsewhere.
 
 ### Asking for General Help
@@ -113,8 +113,8 @@ functional guidelines of the Alloy project.
 Pull Requests are the way concrete changes are made to the code, documentation,
 and dependencies in the Alloy repository.
 
-Before making a large change, it is  usually a good idea to first open an issue 
-describing the change to solicit feedback and guidance. This will increase the 
+Before making a large change, it is usually a good idea to first open an issue
+describing the change to solicit feedback and guidance. This will increase the
 likelihood of the PR getting merged.
 
 When opening a PR **please select the "Allow Edits From Maintainers" option**.
@@ -146,7 +146,7 @@ cargo run --example $YOUR_EXAMPLE_NAME
 To run all (runnable) examples:
 
 ```sh
-./scripts/run.sh
+./scripts/test.sh
 ```
 
 ### Tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -64,7 +64,7 @@ function main () {
 
     # Run all the examples that are left after filtering.
     printf '%s\n' $examples \
-    | xargs -P10 -I{} bash -c '
+    | xargs -P4 -I{} bash -c '
         bin="./target/debug/examples/{}"
         if [[ -x "$bin" ]]; then
             "$bin" >/dev/null \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,12 +7,9 @@ set -eo pipefail
 #
 # 1. Gather all the examples from the output of `cargo run --example` command.
 # 2. Filter out the examples that have external dependencies or are not meant to be run.
-# 1. Run all examples that are left after filtering.
+# 3. Pre-build the filtered examples prior to running them.
+# 4. Run all the examples in parallel (up to 10) that are left after filtering.
 function main () {
-    # Change directory to project root
-    SCRIPT_PATH="$(cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd)"
-    cd "$SCRIPT_PATH/.." || exit
-
     export examples="$(
         cargo run --example 2>&1 \
             | grep -E '^ ' \
@@ -47,7 +44,7 @@ function main () {
             | xargs -n1 echo
     )"
 
-    # Pre-build the examples prior to running them
+    # Pre-build the filtered examples prior to running them.
     cargo build $(printf -- '--example %s ' $examples)
 
     # Run all the examples that are left after filtering.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,17 @@
 # Exit if anything fails.
 set -eo pipefail
 
+# Utilities
+GREEN="\033[00;32m"
+
+function log () {
+  echo -e "$1"
+  echo "################################################################################"
+  echo "#### $2 "
+  echo "################################################################################"
+  echo -e "\033[0m"
+}
+
 # This script will do the following:
 #
 # 1. Gather all the examples from the output of `cargo run --example` command.
@@ -44,12 +55,16 @@ function main () {
             | xargs -n1 echo
     )"
 
+    log $GREEN "Building..."
+
     # Pre-build the filtered examples prior to running them.
     cargo build $(printf -- '--example %s ' $examples)
 
+    log $GREEN "Running..."
+
     # Run all the examples that are left after filtering.
     printf '%s\n' $examples \
-    | xargs -n1 -P10 -I{} bash -c '
+    | xargs -P10 -I{} bash -c '
         bin="./target/debug/examples/{}"
         if [[ -x "$bin" ]]; then
             "$bin" >/dev/null \
@@ -60,6 +75,8 @@ function main () {
             exit 1
         fi
         '
+
+    log $GREEN "Done"
 }
 
 # Run the main function.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Speed up CI by building the examples once and then running them in parallel, now possible as we are using our own RPCs

Cuts down to < 3 mins without a build cache, down from 10 mins+ with

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes