### PR TITLE
fix: use correct duration for mulitcall batching

### DIFF
--- a/examples/providers/examples/multicall_batching.rs
+++ b/examples/providers/examples/multicall_batching.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         // The `CallBatchLayer` will wait for a certain amount of time before sending a request. See: <https://docs.rs/alloy-provider/latest/alloy_provider/layers/struct.CallBatchLayer.html#method.wait>.
         // This delay is added to aggregate any incoming `eth_calls` that can be together.
         // In this case, we set the delay to 10ms.
-        .layer(CallBatchLayer::new().wait(Duration::from_secs(10)))
+        .layer(CallBatchLayer::new().wait(Duration::from_millis(10)))
         // Can also use the shorthand `with_call_batching` on the build which set the delay to 1ms.
         // .with_call_batching()
         .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/examples/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Saw a mismatch in comments and code for an multicall example

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Chose the lower duration value. Feel free to close this PR since it's a typo, just wanted to highlight

## PR Checklist

- [ ] Added Documentation
- [ ] Breaking changes