### PR TITLE
Fix/eip7702 anvil mnemonic 

### DIFF
--- a/examples/transactions/examples/permit2_signature_transfer.rs
+++ b/examples/transactions/examples/permit2_signature_transfer.rs
@@ -64,7 +64,14 @@ async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH.
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
-    let anvil = Anvil::new().fork(rpc_url).try_spawn()?;
+    // NOTE: ⚠️ Due to changes in EIP-7702 (see: https://getfoundry.sh/anvil/overview/#eip-7702-and-default-accounts),
+    // the default mnemonic cannot be used for signature-based testing.
+    // Instead, we use a custom mnemonic generated via:
+    // `anvil --mnemonic-random 12 --fork-url $RPC_URL`
+    let anvil = Anvil::new()
+        .fork(rpc_url)
+        .mnemonic("tunnel tiger ankle life lift risk wash material promote damp sadness middle")
+        .try_spawn()?;
 
     // Set up signers from the first two default Anvil accounts (Alice, Bob).
     let alice: PrivateKeySigner = anvil.keys()[8].clone().into();


### PR DESCRIPTION
## Motivation

When running the original example, it failed.

Then found [this info](https://t.me/ethers_rs/45539) from Telegram chat.

Due to recent changes introduced in [EIP-7702](https://getfoundry.sh/anvil/overview/#eip-7702-and-default-accounts), the default Anvil mnemonic is no longer suitable for signature-based testing. This causes issues when using Anvil accounts for EIP-712 or other signing workflows, as the ephemeral keys do not behave consistently.

## Solution

Replaced the previous usage of `Anvil::new().fork().try_spawn()?` with a custom mnemonic-based Anvil instance. This ensures deterministic and reusable private keys for consistent behavior in signing and transaction testing.

Added inline documentation explaining the rationale, along with the command to generate such mnemonic-based forks via CLI.

## PR Checklist

- [x] Added Documentation