### PR TITLE
Replace hardcoded mnemonic with a randomly generated one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,6 @@ serde_json = "1.0"
 # benchmarking
 criterion = "0.5"
 ethers = "2.0.14"
+
+# rand
+rand = "0.8.5"

--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -16,4 +16,5 @@ workspace = true
 alloy = { workspace = true, features = ["eip712"]}
 
 eyre.workspace = true
+rand.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/examples/transactions/examples/permit2_signature_transfer.rs
+++ b/examples/transactions/examples/permit2_signature_transfer.rs
@@ -70,7 +70,8 @@ async fn main() -> Result<()> {
     // Ensure `anvil` is available in $PATH.
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
     // NOTE: ⚠️ Due to changes in EIP-7702 (see: https://getfoundry.sh/anvil/overview/#eip-7702-and-default-accounts),
-    // the default mnemonic cannot be used for signature-based testing. Instead, we use a custom mnemonic.
+    // the default mnemonic cannot be used for signature-based testing. Instead, we use a custom
+    // mnemonic.
     let mnemonic = generate_mnemonic()?;
     let anvil = Anvil::new().fork(rpc_url).mnemonic(mnemonic).try_spawn()?;
 

--- a/examples/transactions/examples/permit2_signature_transfer.rs
+++ b/examples/transactions/examples/permit2_signature_transfer.rs
@@ -1,17 +1,22 @@
 //! Example of how to transfer ERC20 tokens from one account to another using a signed permit.
 
-use std::str::FromStr;
-
 use alloy::{
     network::EthereumWallet,
     node_bindings::Anvil,
     primitives::{Address, U256},
     providers::{Provider, ProviderBuilder},
-    signers::{local::PrivateKeySigner, Signer},
+    signers::{
+        local::{
+            coins_bip39::{English, Mnemonic},
+            PrivateKeySigner,
+        },
+        Signer,
+    },
     sol,
     sol_types::eip712_domain,
 };
 use eyre::Result;
+use std::str::FromStr;
 
 // Codegen from artifact.
 sol!(
@@ -65,13 +70,9 @@ async fn main() -> Result<()> {
     // Ensure `anvil` is available in $PATH.
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
     // NOTE: ⚠️ Due to changes in EIP-7702 (see: https://getfoundry.sh/anvil/overview/#eip-7702-and-default-accounts),
-    // the default mnemonic cannot be used for signature-based testing.
-    // Instead, we use a custom mnemonic generated via:
-    // `anvil --mnemonic-random 12 --fork-url $RPC_URL`
-    let anvil = Anvil::new()
-        .fork(rpc_url)
-        .mnemonic("tunnel tiger ankle life lift risk wash material promote damp sadness middle")
-        .try_spawn()?;
+    // the default mnemonic cannot be used for signature-based testing. Instead, we use a custom mnemonic.
+    let mnemonic = generate_mnemonic()?;
+    let anvil = Anvil::new().fork(rpc_url).mnemonic(mnemonic).try_spawn()?;
 
     // Set up signers from the first two default Anvil accounts (Alice, Bob).
     let alice: PrivateKeySigner = anvil.keys()[8].clone().into();
@@ -145,4 +146,10 @@ async fn main() -> Result<()> {
     assert_eq!(bob_after_balance - bob_before_balance, amount);
 
     Ok(())
+}
+
+fn generate_mnemonic() -> Result<String> {
+    let mut rng = rand::thread_rng();
+    let mnemonic = Mnemonic::<English>::new_with_count(&mut rng, 12)?.to_phrase();
+    Ok(mnemonic)
 }

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -23,7 +23,7 @@ gcloud-sdk = { version = "0.27", features = [
     "google-cloud-kms-v1",
     "google-longrunning",
 ] }
-rand = "0.8.5"
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tempfile = "3.19"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Motivation

This PR is to fix this [concern](https://github.com/alloy-rs/examples/pull/229#issuecomment-3053173254).
It's an extension of #229.

## Solution

- Introduced a new helper function `generate_mnemonic()` to generate a random 12-word English mnemonic.
- This generated mnemonic is then passed to the `.mnemonic(...)` method when initializing the Anvil instance, replacing the previously hardcoded static phrase.

