### PR TITLE
fix(script): make `test.sh` to work

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,23 +56,26 @@ function main () {
     log $GREEN "Building..."
 
     # Pre-build the filtered examples prior to running them.
-    cargo build $(printf -- '--example %s ' $examples)
+    cargo build $(printf -- '--example %s ' $(echo "$examples"))
 
     log $GREEN "Running..."
 
-    # Run all the examples that are left after filtering.
-    printf '%s\n' $examples \
-    | xargs -P4 -I{} bash -c '
-        bin="./target/debug/examples/{}"
+    printf '%s\n' $examples | xargs -P4 -I{} bash -c '
+        name="$1"
+        bin="./target/debug/examples/$name"
+
         if [[ -x "$bin" ]]; then
-            "$bin" >/dev/null \
-            && echo "Successfully ran: {}" \
-            || { echo "Failed to run: {}" >&2; exit 1; }
+            if "$bin" >/dev/null; then
+                echo "Successfully ran: $name"
+            else
+                echo "Failed to run: $name" >&2
+                exit 1
+            fi
         else
             echo "Missing binary: $bin" >&2
             exit 1
         fi
-        '
+    ' -- {}
 
     log $GREEN "Done"
 }


### PR DESCRIPTION
## Motivation
When I run `test.sh`, it fails with the below message:
```
xargs: command line cannot be assembled, too long
```
The current `xargs -I{}` approach embeds the argument directly into the `bash -c` string, causing the command to exceed the `ARG_MAX` limit and fail with a "command line too long" error when processing many examples.

## Solution
Pass the placeholder `{}` as a positional argument (`$1`) to `bash -c` instead of using direct string substitution. This prevents shell injection, handles special characters safely, and reduces the risk of hitting command-line length limits.
