### PR TITLE
chore: migrate to alloy 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ significant_drop_tightening = "allow"
 needless_return = "allow"
 
 [workspace.dependencies]
-alloy = { version = "1.1.0", features = [
+alloy = { version = "2.0.0", features = [
     "eips",
     "ens",
     "full",
@@ -140,11 +140,11 @@ http-body-util = "0.1"
 tracing-subscriber = "0.3"
 aws-config = { version = "1.8", default-features = false }
 aws-sdk-kms = { version = "1.77", default-features = false }
-gcloud-sdk = "0.27"
+gcloud-sdk = { version = "0.29", default-features = false }
 tempfile = "3.23"
-foundry-fork-db = "0.19"
-alloy-evm = "0.22"
-revm = { version = "30", default-features = false }
+foundry-fork-db = "0.25"
+alloy-evm = "0.32"
+revm = { version = "37", default-features = false }
 ethabi = "18"
 rlp = "0.6.1"
 rlp-derive = "0.2.0"

--- a/examples/advanced/examples/any_network.rs
+++ b/examples/advanced/examples/any_network.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
     let receipt = builder.send().await?.get_receipt().await?;
 
     // Fetch the `gasUsedForL1` and `l1BlockNumber` fields from the receipt.
-    let arb_fields: ArbOtherFields = receipt.other.deserialize_into()?;
+    let arb_fields: ArbOtherFields = receipt.deserialize_other()?;
     let l1_gas = arb_fields.gas_used_for_l1.to::<u128>();
     let l1_block_number = arb_fields.l1_block_number.to::<u64>();
 

--- a/examples/advanced/examples/foundry_fork_db.rs
+++ b/examples/advanced/examples/foundry_fork_db.rs
@@ -102,8 +102,7 @@ async fn main() -> Result<()> {
 
     let res = evm.transact(configure_tx_env(tx_req)).unwrap();
 
-    let total_spent =
-        U256::from(res.result.tx_gas_used()) * U256::from(basefee) + U256::from(100);
+    let total_spent = U256::from(res.result.tx_gas_used()) * U256::from(basefee) + U256::from(100);
 
     shared.data().do_commit(res.state);
 

--- a/examples/advanced/examples/foundry_fork_db.rs
+++ b/examples/advanced/examples/foundry_fork_db.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
 
     // The `BlockchainDbMeta` is used a identifier when the db is flushed to the disk.
     // This aids in cases where the disk contains data from multiple forks.
-    let meta = BlockchainDbMeta::default().with_block(&block.inner).with_url(&anvil.endpoint());
+    let meta = BlockchainDbMeta::default().with_url(&anvil.endpoint());
 
     let db = BlockchainDb::new(meta, None);
 
@@ -102,7 +102,8 @@ async fn main() -> Result<()> {
 
     let res = evm.transact(configure_tx_env(tx_req)).unwrap();
 
-    let total_spent = U256::from(res.result.gas_used()) * U256::from(basefee) + U256::from(100);
+    let total_spent =
+        U256::from(res.result.tx_gas_used()) * U256::from(basefee) + U256::from(100);
 
     shared.data().do_commit(res.state);
 
@@ -138,12 +139,17 @@ fn configure_evm(
             block.header.excess_blob_gas().unwrap_or_default(),
             SpecId::PRAGUE,
         )),
+        slot_num: 0,
     };
 
     let context = EthEvmContext::new(WrapDatabaseRef(shared), SpecId::PRAGUE).with_block(block_env);
 
-    let evm = RevmEvm::new(context, EthInstructions::default(), EthPrecompiles::default())
-        .with_inspector(NoOpInspector);
+    let evm = RevmEvm::new(
+        context,
+        EthInstructions::new_mainnet_with_spec(SpecId::PRAGUE),
+        EthPrecompiles::new(SpecId::PRAGUE),
+    )
+    .with_inspector(NoOpInspector);
 
     EthEvm::new(evm, false)
 }

--- a/examples/transactions/examples/send_eip4844_transaction.rs
+++ b/examples/transactions/examples/send_eip4844_transaction.rs
@@ -1,7 +1,7 @@
 //! Example showing how to send an [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md) transaction.
 
 use alloy::{
-    consensus::{SidecarBuilder, SimpleCoder},
+    consensus::{BlobTransactionSidecar, SidecarBuilder, SimpleCoder},
     eips::eip4844::DATA_GAS_PER_BLOB,
     network::{TransactionBuilder, TransactionBuilder4844},
     providers::{Provider, ProviderBuilder},
@@ -23,11 +23,11 @@ async fn main() -> Result<()> {
 
     // Create a sidecar with some data.
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Blobs are fun!");
-    let sidecar = sidecar.build()?;
+    let sidecar: BlobTransactionSidecar = sidecar.build()?;
 
     // Build a transaction to send the sidecar from Alice to Bob.
     // The `from` field is automatically filled to the first signer's address (Alice).
-    let tx = TransactionRequest::default().with_to(bob).with_blob_sidecar(sidecar);
+    let tx = TransactionRequest::default().with_to(bob).with_blob_sidecar(sidecar.into());
 
     // Send the transaction and wait for the broadcast.
     let pending_tx = provider.send_transaction(tx).await?;

--- a/examples/transactions/examples/send_eip7594_transaction.rs
+++ b/examples/transactions/examples/send_eip7594_transaction.rs
@@ -2,7 +2,8 @@
 
 use alloy::{
     consensus::{
-        EnvKzgSettings, EthereumTxEnvelope, SidecarBuilder, SimpleCoder, TxEip4844WithSidecar,
+        BlobTransactionSidecarVariant, EthereumTxEnvelope, SidecarBuilder, SimpleCoder,
+        TxEip4844WithSidecar,
     },
     eips::{eip7594::BlobTransactionSidecarEip7594, Encodable2718},
     network::{TransactionBuilder, TransactionBuilder4844},
@@ -23,22 +24,24 @@ async fn main() -> Result<()> {
     let alice = accounts[0];
     let bob = accounts[1];
 
-    // Create a sidecar with some data.
+    // Create a sidecar with some data and build it directly as an EIP-7594 sidecar.
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Blobs are fun!");
-    let sidecar = sidecar.build()?;
+    let sidecar: BlobTransactionSidecarEip7594 = sidecar.build()?;
 
     // Build a transaction to send the sidecar from Alice to Bob.
     // The `from` field is automatically filled to the first signer's address (Alice).
-    let tx = TransactionRequest::default().with_to(bob).with_blob_sidecar(sidecar);
+    let tx = TransactionRequest::default()
+        .with_to(bob)
+        .with_blob_sidecar(BlobTransactionSidecarVariant::Eip7594(sidecar));
 
     // Fill the transaction (e.g., nonce, gas, etc.) using the provider and convert it to an
     // envelope.
     let envelope = provider.fill(tx).await?.try_into_envelope()?;
 
-    // Convert the envelope into an EIP-7594 transaction by converting the sidecar.
+    // Convert the envelope into a pooled transaction with EIP-7594 sidecar.
     let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> =
         envelope.try_into_pooled()?.try_map_eip4844(|tx| {
-            tx.try_map_sidecar(|sidecar| sidecar.try_into_7594(EnvKzgSettings::Default.get()))
+            tx.try_map_sidecar(|sidecar| sidecar.try_into_eip7594())
         })?;
 
     let encoded_tx = tx.encoded_2718();
@@ -48,16 +51,8 @@ async fn main() -> Result<()> {
 
     println!("Pending transaction... {}", pending_tx.tx_hash());
 
-    // // Wait for the transaction to be included and get the receipt.
+    // Wait for the transaction to be included and get the receipt.
     let receipt = pending_tx.get_receipt().await?;
-
-    println!(
-        "Transaction included in block {}",
-        receipt.block_number.expect("Failed to get block number")
-    );
-
-    assert_eq!(receipt.from, alice);
-    assert_eq!(receipt.to, Some(bob));
 
     println!(
         "Transaction included in block {}",

--- a/examples/transactions/examples/send_eip7594_transaction.rs
+++ b/examples/transactions/examples/send_eip7594_transaction.rs
@@ -39,10 +39,9 @@ async fn main() -> Result<()> {
     let envelope = provider.fill(tx).await?.try_into_envelope()?;
 
     // Convert the envelope into a pooled transaction with EIP-7594 sidecar.
-    let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> =
-        envelope.try_into_pooled()?.try_map_eip4844(|tx| {
-            tx.try_map_sidecar(|sidecar| sidecar.try_into_eip7594())
-        })?;
+    let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> = envelope
+        .try_into_pooled()?
+        .try_map_eip4844(|tx| tx.try_map_sidecar(|sidecar| sidecar.try_into_eip7594()))?;
 
     let encoded_tx = tx.encoded_2718();
 

--- a/examples/transactions/examples/send_private_transaction.rs
+++ b/examples/transactions/examples/send_private_transaction.rs
@@ -1,7 +1,9 @@
 //! Example of sending a private transaction using Flashbots Protect.
 
 use alloy::{
-    network::{eip2718::Encodable2718, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder},
+    network::{
+        eip2718::Encodable2718, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder,
+    },
     primitives::U256,
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,

--- a/examples/transactions/examples/send_private_transaction.rs
+++ b/examples/transactions/examples/send_private_transaction.rs
@@ -1,7 +1,7 @@
 //! Example of sending a private transaction using Flashbots Protect.
 
 use alloy::{
-    network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder},
+    network::{eip2718::Encodable2718, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder},
     primitives::U256,
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,

--- a/examples/transactions/examples/send_raw_transaction.rs
+++ b/examples/transactions/examples/send_raw_transaction.rs
@@ -1,7 +1,7 @@
 //! Example of signing, encoding and sending a raw transaction using a wallet.
 
 use alloy::{
-    network::TransactionBuilder,
+    network::{NetworkTransactionBuilder, TransactionBuilder},
     primitives::U256,
     providers::{Provider, ProviderBuilder, WalletProvider},
     rpc::types::TransactionRequest,


### PR DESCRIPTION
Bumps all crates to their latest alloy 2.0-compatible versions:

- `alloy` 1.1.0 → 2.0.0
- `revm` 30 → 37
- `alloy-evm` 0.22 → 0.32
- `foundry-fork-db` 0.19 → 0.25
- `gcloud-sdk` 0.27 → 0.29

### Breaking changes addressed

- `SidecarBuilder::build()` is now generic — callers specify `BlobTransactionSidecar` or `BlobTransactionSidecarEip7594`
- `with_blob_sidecar()` takes `BlobTransactionSidecarVariant` instead of a concrete sidecar type
- `TransactionBuilder::build()` moved to `NetworkTransactionBuilder` — added the import where needed
- `AnyTransactionReceipt` is a dedicated struct — use `.deserialize_other()` instead of `.other.deserialize_into()`
- `BlockchainDbMeta::with_block()` removed
- `BlockEnv` gained `slot_num` field (EIP-7843 / Amsterdam)
- `EthInstructions::default()` / `EthPrecompiles::default()` removed — use `new_mainnet_with_spec()` / `new()`
- `gas_used()` deprecated — use `tx_gas_used()`

Prompted by: mattsse