### PR TITLE
feat(examples): add chunked logs query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This repository contains the following examples:
   - [x] [Query contract storage](./examples/queries/examples/query_contract_storage.rs)
   - [x] [Query contract deployed bytecode](./examples/queries/examples/query_deployed_bytecode.rs)
   - [x] [Query logs](./examples/queries/examples/query_logs.rs)
+  - [x] [Query logs in chunks](./examples/queries/examples/query_logs_chunked.rs)
 - [x] `sol!` macro
   - [x] [Contracts](./examples/contracts/examples/deploy_from_contract.rs)
   - [x] [Events and errors](./examples/sol-macro/examples/events_errors.rs)

--- a/examples/queries/examples/query_logs_chunked.rs
+++ b/examples/queries/examples/query_logs_chunked.rs
@@ -1,0 +1,52 @@
+//! Example of querying event logs over a large block range using `chunked()`.
+//!
+//! Some JSON-RPC providers limit the block range for `eth_getLogs` requests.
+//! This first tries the full range in a single request.
+//! If that fails, it splits the range into chunks and queries them concurrently.
+//! If a chunk still fails, it falls back to querying each block individually.
+
+use alloy::{
+    contract::Event,
+    primitives::address,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::Filter,
+    sol,
+    sol_types::SolEvent,
+};
+use eyre::Result;
+
+sol! {
+    #[allow(missing_docs)]
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create a provider.
+    let rpc_url = "https://ethereum-rpc.publicnode.com".parse()?;
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
+
+    let latest_block = provider.get_block_number().await?;
+
+    let uniswap_token_address = address!("1f9840a85d5aF5bf1D1762F925BDADdC4201F984");
+    let filter = Filter::new()
+        .address(uniswap_token_address)
+        .event_signature(Transfer::SIGNATURE_HASH)
+        .from_block(latest_block - 50_000)
+        .to_block(latest_block);
+    // You could also use the event name instead of the event signature like so:
+    // .event("Transfer(address,address,uint256)")
+
+    let event: Event<_, Transfer, _> = Event::new(&provider, filter);
+    // Query the last 50,000 blocks for UNI Transfer events, splitting the range into
+    // 250-block chunks queried with 4 concurrent requests.
+    let transfers = event.chunked().chunk_size(250).concurrent(4).query().await?;
+
+    for (Transfer { from, to, value }, _) in &transfers {
+        println!("Transfer from {from} to {to} of value {value}");
+    }
+
+    println!("Fetched {} UNI Transfer logs across the last 50,000 blocks", transfers.len());
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

There isn't yet an example in the repository for chunked log queries, which may be useful for users querying over large block ranges.

## Solution

Add a `query_logs_chunked` example under `examples/queries/` that demonstrates `Event::chunked()` with `chunk_size` and `concurrent` configured. The `README` is also updated.

## PR Checklist

- [x] Added Documentation
- [ ] Breaking changes