### PR TITLE
feat(examples): cover resilient provider workflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ alloy = { version = "2.0.0", features = [
     "signer-ledger",
     "signer-mnemonic",
     "signer-trezor",
+    "signer-turnkey",
     "signer-yubihsm",
     "kzg",
 ] }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This repository contains the following examples:
   - [x] [Multicall Builder](./examples/providers/examples/multicall.rs)
   - [x] [WS](./examples/providers/examples/ws.rs)
   - [x] [WS with authentication](./examples/providers/examples/ws_with_auth.rs)
+  - [x] [WS with configurable reconnects](./examples/providers/examples/ws_with_reconnect.rs)
   - [x] [JSON-RPC Batch Request](./examples/providers/examples/batch_rpc.rs)
   - [x] [Consensus x RPC types unification](./examples/providers/examples/embed_consensus_rpc.rs)
   - [x] [Basic provider with no fillers](./examples/providers/examples/basic_provider.rs)
@@ -124,6 +125,7 @@ This repository contains the following examples:
   - [x] [`extra_derives` attribute](./examples/sol-macro/examples/extra_derives.rs)
 - [x] Subscriptions
   - [x] [Subscribe and watch blocks](./examples/subscriptions/examples/subscribe_blocks.rs)
+  - [x] [Resume a canonical block stream](./examples/subscriptions/examples/watch_canonical_blocks.rs)
   - [x] [Watch and poll for contract event logs](./examples/subscriptions/examples/poll_logs.rs)
   - [x] [Subscribe and listen for specific contract event logs](./examples/subscriptions/examples/subscribe_logs.rs)
   - [x] [Subscribe and listen for all contract event logs](./examples/subscriptions/examples/subscribe_all_logs.rs)
@@ -160,6 +162,7 @@ This repository contains the following examples:
   - [x] [Verify message](./examples/wallets/examples/verify_message.rs)
   - [x] [Sign permit hash](./examples/wallets/examples/sign_permit_hash.rs)
   - [x] [Trezor signer](./examples/wallets/examples/trezor_signer.rs)
+  - [x] [Turnkey signer](./examples/wallets/examples/turnkey_signer.rs)
   - [x] [Yubi signer](./examples/wallets/examples/yubi_signer.rs)
   - [x] [Keystore signer](./examples/wallets/examples/keystore_signer.rs)
   - [x] [Create keystore](./examples/wallets/examples/create_keystore.rs)

--- a/examples-index.json
+++ b/examples-index.json
@@ -1195,6 +1195,25 @@
       }
     },
     {
+      "name": "ws_with_reconnect",
+      "category": "providers",
+      "package": "examples-providers",
+      "source": "examples/providers/examples/ws_with_reconnect.rs",
+      "summary": "Example of configuring WebSocket connection and reconnection retries.",
+      "command": "cargo run --locked -p examples-providers --example ws_with_reconnect",
+      "runtime": {
+        "class": "configured-network",
+        "network": "user-supplied",
+        "environment": [
+          "WS_URL"
+        ],
+        "arguments": [],
+        "binaries": [],
+        "hardware": [],
+        "services": []
+      }
+    },
+    {
       "name": "query_contract_storage",
       "category": "queries",
       "package": "examples-queries",
@@ -1484,6 +1503,25 @@
         ],
         "arguments": [],
         "binaries": [],
+        "hardware": [],
+        "services": []
+      }
+    },
+    {
+      "name": "watch_canonical_blocks",
+      "category": "subscriptions",
+      "package": "examples-subscriptions",
+      "source": "examples/subscriptions/examples/watch_canonical_blocks.rs",
+      "summary": "Example of resuming a canonical block stream from a known block number.",
+      "command": "cargo run --locked -p examples-subscriptions --example watch_canonical_blocks",
+      "runtime": {
+        "class": "local-node",
+        "network": "local-development",
+        "environment": [],
+        "arguments": [],
+        "binaries": [
+          "anvil"
+        ],
         "hardware": [],
         "services": []
       }
@@ -2069,6 +2107,29 @@
           "Trezor device"
         ],
         "services": []
+      }
+    },
+    {
+      "name": "turnkey_signer",
+      "category": "wallets",
+      "package": "examples-wallets",
+      "source": "examples/wallets/examples/turnkey_signer.rs",
+      "summary": "Example showing how to use the Turnkey managed signer.",
+      "command": "cargo run --locked -p examples-wallets --example turnkey_signer",
+      "runtime": {
+        "class": "cloud-credentials",
+        "network": null,
+        "environment": [
+          "TURNKEY_ADDRESS",
+          "TURNKEY_API_PRIVATE_KEY",
+          "TURNKEY_ORGANIZATION_ID"
+        ],
+        "arguments": [],
+        "binaries": [],
+        "hardware": [],
+        "services": [
+          "Turnkey"
+        ]
       }
     },
     {

--- a/examples/providers/examples/ws_with_reconnect.rs
+++ b/examples/providers/examples/ws_with_reconnect.rs
@@ -1,0 +1,19 @@
+//! Example of configuring WebSocket connection and reconnection retries.
+
+use alloy::providers::{ConnectionConfig, Provider, ProviderBuilder};
+use example_support::ws_url;
+use eyre::Result;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let endpoint = ws_url()?;
+    let config =
+        ConnectionConfig::new().with_max_retries(10).with_retry_interval(Duration::from_secs(1));
+
+    // The same retry policy is used for the initial connection and later WebSocket reconnects.
+    let provider = ProviderBuilder::new().connect_with_config(&endpoint, config).await?;
+
+    println!("Connected to chain {}", provider.get_chain_id().await?);
+    Ok(())
+}

--- a/examples/subscriptions/Cargo.toml
+++ b/examples/subscriptions/Cargo.toml
@@ -18,4 +18,4 @@ example-support.workspace = true
 
 eyre.workspace = true
 futures-util.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }

--- a/examples/subscriptions/examples/watch_canonical_blocks.rs
+++ b/examples/subscriptions/examples/watch_canonical_blocks.rs
@@ -1,0 +1,45 @@
+//! Example of resuming a canonical block stream from a known block number.
+
+use alloy::{
+    node_bindings::Anvil,
+    providers::{CanonicalEvent, Provider, ProviderBuilder},
+};
+use eyre::{eyre, Result, WrapErr};
+use futures_util::StreamExt;
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Run against a local node so this example is deterministic and needs no endpoint.
+    // Ensure `anvil` is available in PATH.
+    let anvil = Anvil::new().try_spawn()?;
+    let provider = ProviderBuilder::new().connect(&anvil.endpoint()).await?;
+
+    // Persist this value in a real indexer, then reuse it after a restart. The stream first
+    // backfills from this block and subsequently polls for new canonical blocks.
+    let resume_from = 0;
+    let mut blocks = provider
+        .watch_canonical_blocks_from(resume_from)
+        .poll_interval(Duration::from_millis(100))
+        .full()
+        .max_reorg_depth(64)
+        .into_stream();
+
+    let event = timeout(Duration::from_secs(5), blocks.next())
+        .await
+        .wrap_err("timed out waiting for the canonical block stream")?
+        .ok_or_else(|| eyre!("canonical block stream ended unexpectedly"))??;
+
+    match event {
+        CanonicalEvent::Added(block) => {
+            println!("Added canonical block {}", block.header.number);
+            assert_eq!(block.header.number, resume_from);
+        }
+        CanonicalEvent::Removed(block) => {
+            println!("Removed reorged block {}", block.header.number);
+        }
+    }
+
+    Ok(())
+}

--- a/examples/wallets/examples/turnkey_signer.rs
+++ b/examples/wallets/examples/turnkey_signer.rs
@@ -1,0 +1,25 @@
+//! Example showing how to use the Turnkey managed signer.
+
+use alloy::{
+    primitives::Address,
+    signers::{turnkey::TurnkeySigner, Signer},
+};
+use example_support::required_env;
+use eyre::{Result, WrapErr};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let organization_id = required_env("TURNKEY_ORGANIZATION_ID")?;
+    let api_private_key = required_env("TURNKEY_API_PRIVATE_KEY")?;
+    let address: Address = required_env("TURNKEY_ADDRESS")?
+        .parse()
+        .wrap_err("TURNKEY_ADDRESS must be a valid Ethereum address")?;
+
+    let signer = TurnkeySigner::from_api_key(&api_private_key, organization_id, address, Some(1))?;
+
+    let message = "Hello, world!";
+    let signature = signer.sign_message(message.as_bytes()).await?;
+    assert_eq!(signature.recover_address_from_msg(message)?, signer.address());
+
+    Ok(())
+}

--- a/scripts/generate-example-index.py
+++ b/scripts/generate-example-index.py
@@ -115,7 +115,7 @@ def environment_from(source: str) -> list[str]:
     return sorted(names)
 
 
-def runtime_metadata(name: str, source: str, offline: set[str]) -> dict:
+def runtime_metadata(name: str, source: str, runtime_allowlist: set[str]) -> dict:
     environment = environment_from(source)
     binaries = []
     hardware = []
@@ -148,15 +148,15 @@ def runtime_metadata(name: str, source: str, offline: set[str]) -> dict:
         services.append("AWS KMS")
     if "GcpSigner" in source:
         services.append("Google Cloud KMS")
+    if "TurnkeySigner" in source:
+        services.append("Turnkey")
 
     if name in {"compare_new_heads", "compare_pending_txs"}:
         arguments.append("-r <name>:<url> (repeat for each provider)")
 
-    if name in offline:
-        runtime_class = "offline"
-    elif hardware:
+    if hardware:
         runtime_class = "hardware"
-    elif any(service.endswith("KMS") for service in services):
+    elif any(service.endswith("KMS") for service in services) or "Turnkey" in services:
         runtime_class = "cloud-credentials"
     elif arguments or environment:
         runtime_class = "configured-network"
@@ -164,6 +164,8 @@ def runtime_metadata(name: str, source: str, offline: set[str]) -> dict:
         runtime_class = "external-service"
     elif binaries:
         runtime_class = "local-node"
+    elif name in runtime_allowlist:
+        runtime_class = "offline"
     elif "std::fs::" in source or "read_to_string" in source:
         runtime_class = "local-filesystem"
     else:
@@ -194,7 +196,7 @@ def runtime_metadata(name: str, source: str, offline: set[str]) -> dict:
 
 def build_index() -> dict:
     metadata = load_metadata()
-    offline = load_runtime_allowlist()
+    runtime_allowlist = load_runtime_allowlist()
     examples = []
 
     for package in metadata["packages"]:
@@ -220,7 +222,7 @@ def build_index() -> dict:
                     "command": (
                         f"cargo run --locked -p {package_name} --example {target['name']}"
                     ),
-                    "runtime": runtime_metadata(target["name"], source, offline),
+                    "runtime": runtime_metadata(target["name"], source, runtime_allowlist),
                 }
             )
 
@@ -231,7 +233,7 @@ def build_index() -> dict:
         raise SystemExit(f"Duplicate example target names: {', '.join(duplicates)}")
 
     target_names = set(names)
-    unknown_allowlist = sorted(offline - target_names)
+    unknown_allowlist = sorted(runtime_allowlist - target_names)
     if unknown_allowlist:
         raise SystemExit(
             "Unknown examples in scripts/runtime-examples.txt: " + ", ".join(unknown_allowlist)

--- a/scripts/runtime-examples.txt
+++ b/scripts/runtime-examples.txt
@@ -1,4 +1,4 @@
-# Deterministic examples that require no RPC service, node process, credentials, or hardware.
+# Deterministic examples validated at runtime by CI. The workflow provides required binaries.
 decoding_json_abi
 encoding_dyn_abi
 encoding_sol_static
@@ -24,3 +24,4 @@ mnemonic_signer
 sign_message
 sign_permit_hash
 verify_message
+watch_canonical_blocks


### PR DESCRIPTION
## Summary

- add a resumable canonical-block stream example that handles reorg events and runs deterministically against Anvil
- demonstrate configurable WebSocket connection and reconnection retry policies
- add the missing Turnkey managed-signer example and expose its runtime requirements in the generated catalog

## Why

The examples catalog covered basic subscriptions and WebSocket connections, but not restart-safe canonical ingestion, reconnect configuration, or Alloy’s Turnkey signer integration. These are common production workflows and are now directly discoverable by both readers and agents.