### PR TITLE
fix(ci): attribute dependency updates to bot

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: ${{ env.TITLE }}
           body: ${{ steps.msg.outputs.body }}
           branch: ${{ env.BRANCH }}


### PR DESCRIPTION
The weekly dependency workflow currently inherits the scheduled workflow actor as the generated commit author. This causes automated dependency commits to be attributed to the user associated with the schedule, even though GitHub Actions creates and pushes them.

Explicitly configure both the author and committer inputs for `peter-evans/create-pull-request` as `github-actions[bot]`. Future dependency-update commits and their pull requests will therefore be consistently bot-attributed, independent of the scheduled workflow actor.
