### PR TITLE
feat(examples): add canonical log stream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This repository contains the following examples:
 - [x] Subscriptions
   - [x] [Subscribe and watch blocks](./examples/subscriptions/examples/subscribe_blocks.rs)
   - [x] [Resume a canonical block stream](./examples/subscriptions/examples/watch_canonical_blocks.rs)
+  - [x] [Resume a canonical log stream](./examples/subscriptions/examples/watch_canonical_logs.rs)
   - [x] [Watch and poll for contract event logs](./examples/subscriptions/examples/poll_logs.rs)
   - [x] [Subscribe and listen for specific contract event logs](./examples/subscriptions/examples/subscribe_logs.rs)
   - [x] [Subscribe and listen for all contract event logs](./examples/subscriptions/examples/subscribe_all_logs.rs)

--- a/examples-index.json
+++ b/examples-index.json
@@ -1527,6 +1527,25 @@
       }
     },
     {
+      "name": "watch_canonical_logs",
+      "category": "subscriptions",
+      "package": "examples-subscriptions",
+      "source": "examples/subscriptions/examples/watch_canonical_logs.rs",
+      "summary": "Example of resuming a canonical log stream from a known block number.",
+      "command": "cargo run --locked -p examples-subscriptions --example watch_canonical_logs",
+      "runtime": {
+        "class": "local-node",
+        "network": "local-development",
+        "environment": [],
+        "arguments": [],
+        "binaries": [
+          "anvil"
+        ],
+        "hardware": [],
+        "services": []
+      }
+    },
+    {
       "name": "debug_trace_call_many",
       "category": "transactions",
       "package": "examples-transactions",

--- a/examples/subscriptions/examples/watch_canonical_logs.rs
+++ b/examples/subscriptions/examples/watch_canonical_logs.rs
@@ -1,0 +1,55 @@
+//! Example of resuming a canonical log stream from a known block number.
+
+use alloy::{
+    node_bindings::Anvil,
+    providers::{CanonicalEvent, Provider, ProviderBuilder},
+    rpc::types::Filter,
+};
+use eyre::{eyre, Result, WrapErr};
+use futures_util::StreamExt;
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Run against a local node so this example is deterministic and needs no endpoint.
+    // Ensure `anvil` is available in PATH.
+    let anvil = Anvil::new().try_spawn()?;
+    let provider = ProviderBuilder::new().connect(&anvil.endpoint()).await?;
+
+    let filter = Filter::new().event("Transfer(address,address,uint256)");
+
+    // Persist this value in a real indexer, then reuse it after a restart. The stream first
+    // backfills from this block and subsequently polls for new canonical blocks.
+    let resume_from = 0;
+    let mut logs = provider
+        .watch_canonical_logs_from(resume_from, &filter)
+        .poll_interval(Duration::from_millis(100))
+        .max_reorg_depth(64)
+        .into_stream();
+
+    let event = timeout(Duration::from_secs(5), logs.next())
+        .await
+        .wrap_err("timed out waiting for the canonical log stream")?
+        .ok_or_else(|| eyre!("canonical log stream ended unexpectedly"))??;
+
+    match event {
+        CanonicalEvent::Added(block_logs) => {
+            println!(
+                "Added canonical block {} with {} matching logs",
+                block_logs.block.header.number,
+                block_logs.logs.len()
+            );
+            assert_eq!(block_logs.block.header.number, resume_from);
+        }
+        CanonicalEvent::Removed(block_logs) => {
+            println!(
+                "Removed reorged block {} with {} matching logs",
+                block_logs.block.header.number,
+                block_logs.logs.len()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/scripts/runtime-examples.txt
+++ b/scripts/runtime-examples.txt
@@ -26,3 +26,4 @@ sign_message
 sign_permit_hash
 verify_message
 watch_canonical_blocks
+watch_canonical_logs


### PR DESCRIPTION
## Motivation

The repository includes an example of `watch_canonical_blocks_from`, but not of `watch_canonical_logs_from`. An example may be useful for users building log indexers.

## Solution

Add a `watch_canonical_logs_from` example following the existing `watch_canonical_blocks_from` example.

## PR Checklist

- [x] Added Documentation
- [ ] Breaking changes